### PR TITLE
Define asset root at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,11 @@ target_include_directories(widgecraft
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party
 )
 
+target_compile_definitions(widgecraft
+    PRIVATE
+        WIDGECRAFT_ASSET_DIR="${CMAKE_CURRENT_SOURCE_DIR}/assets"
+)
+
 target_link_libraries(widgecraft PRIVATE glfw glad)
 
 # ---------------- Warnings ----------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,17 +5,20 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
+#include <filesystem>
 #include <iostream>
 #include <string>
 
-int main() {
+int main(int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
     try {
         WidgeCraft::Window window(800, 600, "WidgeCraft Engine");
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-        const std::string fontPath = "assets/fonts/Roboto-Regular.ttf";
-        WidgeCraft::TextRenderer textRenderer(window.getWidth(), window.getHeight(), fontPath, 64.0f);
+        const std::filesystem::path fontPath = std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "fonts/Roboto-Regular.ttf";
+        WidgeCraft::TextRenderer textRenderer(window.getWidth(), window.getHeight(), fontPath.string(), 64.0f);
 
         while (!window.shouldClose()) {
             glClearColor(0.2f, 0.3f, 0.3f, 1.0f);


### PR DESCRIPTION
## Summary
- define `WIDGECRAFT_ASSET_DIR` for the executable so assets resolve without relying on the CWD
- update `main` to use `std::filesystem` when constructing the font path passed into `TextRenderer`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./widgecraft` *(fails: `Failed to initialize GLFW` in this headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2587e97b88321b99404fdc8f5d66a