### PR TITLE
Fix SDF atlas V coordinate orientation

### DIFF
--- a/src/TextRenderer.cpp
+++ b/src/TextRenderer.cpp
@@ -412,9 +412,9 @@ namespace WidgeCraft {
             glyph.width = static_cast<float>(width);
             glyph.height = static_cast<float>(height);
             glyph.u0 = width > 0 ? static_cast<float>(penX) / static_cast<float>(m_atlasWidth) : 0.0f;
-            glyph.v0 = height > 0 ? static_cast<float>(penY) / static_cast<float>(m_atlasHeight) : 0.0f;
+            glyph.v0 = height > 0 ? static_cast<float>(penY + height) / static_cast<float>(m_atlasHeight) : 0.0f;
             glyph.u1 = width > 0 ? static_cast<float>(penX + width) / static_cast<float>(m_atlasWidth) : 0.0f;
-            glyph.v1 = height > 0 ? static_cast<float>(penY + height) / static_cast<float>(m_atlasHeight) : 0.0f;
+            glyph.v1 = height > 0 ? static_cast<float>(penY) / static_cast<float>(m_atlasHeight) : 0.0f;
             glyph.glyphIndex = glyphIndex;
 
             m_glyphs.emplace(static_cast<char>(codepoint), glyph);


### PR DESCRIPTION
## Summary
- flip the generated glyph V texture coordinates so the SDF atlas aligns with OpenGL's origin
- rely on the corrected glyph data for the fallback glyph so it renders upright as well

## Testing
- cmake -S . -B build
- cmake --build build
- xvfb-run -a ./build/widgecraft

------
https://chatgpt.com/codex/tasks/task_e_68d266d447e4832182e03cb0192c5b86