### PR TITLE
Fix baseline for SDF glyph rendering

### DIFF
--- a/src/TextRenderer.cpp
+++ b/src/TextRenderer.cpp
@@ -250,7 +250,8 @@ namespace WidgeCraft {
             }
 
             float xPos = cursorX + glyph->xOffset * scale;
-            float yPos = cursorY + glyph->yOffset * scale;
+            // yOffset is downwards-positive in stb_truetype, so convert to OpenGL's y-up space.
+            float yPos = cursorY - (glyph->yOffset + glyph->height) * scale;
             float w = glyph->width * scale;
             float h = glyph->height * scale;
 


### PR DESCRIPTION
## Summary
- flip glyph y offset from stb_truetype to OpenGL's y-up coordinate space when positioning glyph quads
- document the y offset convention to avoid future regressions

## Testing
- cmake -S . -B build
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_e_68d26a70eb50832185b815c1b321aa3f