### PR TITLE
Use derivative-based smoothing for text fragments

### DIFF
--- a/src/TextRenderer.cpp
+++ b/src/TextRenderer.cpp
@@ -51,7 +51,8 @@ namespace WidgeCraft {
 
             void main() {
                 float distance = texture(uTexture, vTexCoord).r;
-                float alpha = smoothstep(uEdgeValue - uSmoothing, uEdgeValue + uSmoothing, distance);
+                float coverageWidth = max(uSmoothing, fwidth(distance));
+                float alpha = smoothstep(uEdgeValue - coverageWidth, uEdgeValue + coverageWidth, distance);
                 FragColor = vec4(uTextColor, alpha);
             }
         )";
@@ -235,7 +236,8 @@ namespace WidgeCraft {
         glUseProgram(m_shader);
         glUniformMatrix4fv(m_uniformProjection, 1, GL_FALSE, m_projection.data());
         glUniform3f(m_uniformTextColor, color.r, color.g, color.b);
-        glUniform1f(m_uniformSmoothing, m_smoothing / sizeScale);
+        const float minimumWidth = m_smoothing / sizeScale;
+        glUniform1f(m_uniformSmoothing, minimumWidth);
 
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, m_texture);


### PR DESCRIPTION
## Summary
- compute the fragment shader's smoothing width from screen-space derivatives and clamp it with the uniform floor
- treat the smoothing uniform as a minimum coverage width when issuing text draw calls

## Testing
- cmake -S WidgeCraft -B WidgeCraft/build
- cmake --build WidgeCraft/build
- WidgeCraft/build/widgecraft *(fails: GLFW cannot initialize in the headless container)*

------
https://chatgpt.com/codex/tasks/task_e_68d271b702f08321ab99b9d50a6e7a1d