### PR TITLE
Refine SDF coverage width calculation

### DIFF
--- a/src/TextRenderer.cpp
+++ b/src/TextRenderer.cpp
@@ -51,7 +51,8 @@ namespace WidgeCraft {
 
             void main() {
                 float distance = texture(uTexture, vTexCoord).r;
-                float coverageWidth = max(uSmoothing, fwidth(distance));
+                vec2 gradient = vec2(dFdx(distance), dFdy(distance));
+                float coverageWidth = max(uSmoothing, 0.5 * length(gradient));
                 float alpha = smoothstep(uEdgeValue - coverageWidth, uEdgeValue + coverageWidth, distance);
                 FragColor = vec4(uTextColor, alpha);
             }


### PR DESCRIPTION
## Summary
- replace the signed distance coverage window with a gradient magnitude based calculation in the text fragment shader to tighten blending

## Testing
- `cmake --build WidgeCraft/build --config Release`
- `WidgeCraft/build/widgecraft` *(fails: GLFW cannot initialize without a display in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d276c53a44832196683f53b1ac4f25