### PR TITLE
Extract widget hierarchy into dedicated module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ add_executable(widgecraft
     src/main.cpp
     src/Window.cpp
     src/TextRenderer.cpp
+    src/Frame.cpp
+    src/Widget.cpp
 )
 
 target_include_directories(widgecraft

--- a/include/WidgeCraft/Frame.hpp
+++ b/include/WidgeCraft/Frame.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "WidgeCraft/TextRenderer.hpp"
+#include "WidgeCraft/Types.hpp"
+#include "WidgeCraft/Widget.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace WidgeCraft {
+
+    class Frame {
+    public:
+        class TextBatch {
+        public:
+            struct Command {
+                std::string text;
+                Position position;
+                float sizePixels = 0.0f;
+                TextRenderer::Color color{ 1.0f, 1.0f, 1.0f };
+            };
+
+            void addText(std::string text, float x, float y, float sizePixels, TextRenderer::Color color);
+            void clear();
+
+            const std::vector<Command>& getCommands() const { return m_commands; }
+
+        private:
+            std::vector<Command> m_commands;
+        };
+
+        Frame(std::string name, Frame* parent = nullptr);
+        ~Frame() = default;
+
+        Frame(const Frame&) = delete;
+        Frame& operator=(const Frame&) = delete;
+        Frame(Frame&&) noexcept = default;
+        Frame& operator=(Frame&&) noexcept = default;
+
+        const std::string& getName() const { return m_name; }
+
+        void setVisible(bool visible);
+        bool isVisible() const { return m_visible; }
+
+        void setBackgroundVisible(bool visible) { m_showBackground = visible; }
+        bool isBackgroundVisible() const { return m_showBackground; }
+
+        void setBorderVisible(bool visible) { m_showBorder = visible; }
+        bool isBorderVisible() const { return m_showBorder; }
+
+        void setBackgroundColor(Color color) { m_backgroundColor = color; }
+        Color getBackgroundColor() const { return m_backgroundColor; }
+
+        void setPosition(float x, float y);
+        void setPosition(const Position& position) { setPosition(position.x, position.y); }
+        Position getPosition() const { return m_position; }
+
+        void setSize(float width, float height);
+        void setSize(const Size& size) { setSize(size.x, size.y); }
+        Size getSize() const { return m_size; }
+
+        Position getAbsolutePosition() const;
+
+        Frame& createChildFrame(const std::string& name);
+        bool removeChildFrame(const std::string& name);
+
+        template <typename T, typename... Args>
+        T& addWidget(Args&&... args);
+
+        TextBatch& getTextBatch() { return m_textBatch; }
+        const TextBatch& getTextBatch() const { return m_textBatch; }
+
+        const std::vector<std::unique_ptr<Frame>>& getChildren() const { return m_children; }
+        Widgets& getWidgets() { return m_widgets; }
+        const Widgets& getWidgets() const { return m_widgets; }
+
+        Frame* getParent() const { return m_parent; }
+        void setDeletable(bool deletable) { m_deletable = deletable; }
+        bool canBeDeleted() const { return m_deletable; }
+
+        void render(TextRenderer& textRenderer);
+
+    private:
+        void clearTextBatchesRecursive();
+
+        std::string m_name;
+        Frame* m_parent = nullptr;
+        bool m_visible = true;
+        bool m_showBackground = true;
+        bool m_showBorder = false;
+        bool m_deletable = true;
+        Color m_backgroundColor{};
+        Position m_position{};
+        Size m_size{};
+        TextBatch m_textBatch;
+        Widgets m_widgets;
+        std::vector<std::unique_ptr<Frame>> m_children;
+    };
+
+    template <typename T, typename... Args>
+    T& Frame::addWidget(Args&&... args) {
+        return m_widgets.template emplace<T>(std::forward<Args>(args)...);
+    }
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/Types.hpp
+++ b/include/WidgeCraft/Types.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace WidgeCraft {
+
+    struct Color {
+        float r = 0.1f;
+        float g = 0.1f;
+        float b = 0.1f;
+        float a = 1.0f;
+    };
+
+    struct Vec2 {
+        float x = 0.0f;
+        float y = 0.0f;
+    };
+
+    using Position = Vec2;
+    using Size = Vec2;
+
+    struct Offset {
+        float dx = 0.0f;
+        float dy = 0.0f;
+    };
+
+    enum class Anchor {
+        TopLeft,
+        TopCenter,
+        TopRight,
+        CenterLeft,
+        Center,
+        CenterRight,
+        BottomLeft,
+        BottomCenter,
+        BottomRight
+    };
+
+    using Colour = Color;
+
+} // namespace WidgeCraft
+

--- a/include/WidgeCraft/Widget.hpp
+++ b/include/WidgeCraft/Widget.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#include "WidgeCraft/TextRenderer.hpp"
+#include "WidgeCraft/Types.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace WidgeCraft {
+
+    class Frame;
+
+    class Widget {
+    public:
+        explicit Widget(std::string name);
+        virtual ~Widget() = default;
+
+        const std::string& getName() const { return m_name; }
+
+        void setVisible(bool visible);
+        bool isVisible() const { return m_visible; }
+
+        void setPosition(float x, float y);
+        void setPosition(const Position& position) { setPosition(position.x, position.y); }
+        Position getPosition() const { return m_position; }
+
+        void setSize(float width, float height);
+        void setSize(const Size& size) { setSize(size.x, size.y); }
+        Size getSize() const { return m_size; }
+
+        Frame* getParent() const { return m_parent; }
+
+        virtual void render(Frame& frame, TextRenderer& textRenderer) = 0;
+
+        friend class Frame;
+        friend class Widgets;
+
+    protected:
+        void setParent(Frame* parent);
+
+    private:
+        std::string m_name;
+        Frame* m_parent = nullptr;
+        bool m_visible = true;
+        Position m_position{};
+        Size m_size{};
+    };
+
+    class Widgets {
+    public:
+        explicit Widgets(Frame& owner);
+
+        template <typename T, typename... Args>
+        T& emplace(Args&&... args);
+
+        auto begin() { return m_widgets.begin(); }
+        auto end() { return m_widgets.end(); }
+        auto begin() const { return m_widgets.begin(); }
+        auto end() const { return m_widgets.end(); }
+        auto cbegin() const { return m_widgets.cbegin(); }
+        auto cend() const { return m_widgets.cend(); }
+
+        std::vector<std::unique_ptr<Widget>>& getAll() { return m_widgets; }
+        const std::vector<std::unique_ptr<Widget>>& getAll() const { return m_widgets; }
+
+    private:
+        Frame& m_owner;
+        std::vector<std::unique_ptr<Widget>> m_widgets;
+    };
+
+    class Label : public Widget {
+    public:
+        Label(std::string name, std::string text = "");
+
+        void setText(std::string text);
+        const std::string& getText() const { return m_text; }
+
+        void setColor(TextRenderer::Color color) { m_color = color; }
+        TextRenderer::Color getColor() const { return m_color; }
+
+        void setTextSize(float sizePixels) { m_textSizePixels = sizePixels; }
+        float getTextSize() const { return m_textSizePixels; }
+
+        void render(Frame& frame, TextRenderer& textRenderer) override;
+
+    private:
+        std::string m_text;
+        TextRenderer::Color m_color{ 1.0f, 1.0f, 1.0f };
+        float m_textSizePixels = 0.0f;
+    };
+
+    class Button : public Widget {
+    public:
+        Button(std::string name, std::string text = "");
+
+        void setText(std::string text);
+        const std::string& getText() const { return m_text; }
+
+        void setTextColor(TextRenderer::Color color) { m_textColor = color; }
+        TextRenderer::Color getTextColor() const { return m_textColor; }
+
+        void setTextSize(float sizePixels) { m_textSizePixels = sizePixels; }
+        float getTextSize() const { return m_textSizePixels; }
+
+        void setBackgroundVisible(bool visible) { m_showBackground = visible; }
+        bool isBackgroundVisible() const { return m_showBackground; }
+
+        void setBackgroundColor(Color color) { m_backgroundColor = color; }
+        Color getBackgroundColor() const { return m_backgroundColor; }
+
+        void render(Frame& frame, TextRenderer& textRenderer) override;
+
+    private:
+        std::string m_text;
+        TextRenderer::Color m_textColor{ 1.0f, 1.0f, 1.0f };
+        float m_textSizePixels = 0.0f;
+        bool m_showBackground = true;
+        Color m_backgroundColor{};
+    };
+
+    template <typename T, typename... Args>
+    T& Widgets::emplace(Args&&... args) {
+        auto widget = std::make_unique<T>(std::forward<Args>(args)...);
+        widget->setParent(&m_owner);
+        T& reference = *widget;
+        m_widgets.emplace_back(std::move(widget));
+        return reference;
+    }
+
+} // namespace WidgeCraft
+

--- a/include/WidgeCraft/Window.hpp
+++ b/include/WidgeCraft/Window.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include "WidgeCraft/Frame.hpp"
+
 #include <string>
 
 // Forward declaration of GLFW window type
@@ -19,10 +21,14 @@ namespace WidgeCraft {
         int getWidth() const { return m_width; }
         int getHeight() const { return m_height; }
 
+        Frame& getRootFrame() { return m_rootFrame; }
+        const Frame& getRootFrame() const { return m_rootFrame; }
+
     private:
         GLFWwindow* m_window;
         int m_width;
         int m_height;
+        Frame m_rootFrame;
 
         void updateSize(int width, int height);
         static void framebufferSizeCallback(GLFWwindow* window, int width, int height);

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -1,0 +1,123 @@
+#include "WidgeCraft/Frame.hpp"
+
+#include "WidgeCraft/TextRenderer.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace WidgeCraft {
+
+    Frame::Frame(std::string name, Frame* parent)
+        : m_name(std::move(name)), m_parent(parent), m_widgets(*this) {
+    }
+
+    void Frame::setVisible(bool visible) {
+        if (m_visible == visible) {
+            return;
+        }
+
+        m_visible = visible;
+        if (!m_visible) {
+            clearTextBatchesRecursive();
+        }
+    }
+
+    void Frame::setPosition(float x, float y) {
+        m_position.x = x;
+        m_position.y = y;
+    }
+
+    void Frame::setSize(float width, float height) {
+        m_size.x = width;
+        m_size.y = height;
+    }
+
+    Position Frame::getAbsolutePosition() const {
+        if (!m_parent) {
+            return m_position;
+        }
+
+        const Position parentPosition = m_parent->getAbsolutePosition();
+        return { parentPosition.x + m_position.x, parentPosition.y + m_position.y };
+    }
+
+    Frame& Frame::createChildFrame(const std::string& name) {
+        auto child = std::make_unique<Frame>(name, this);
+        Frame& reference = *child;
+        m_children.emplace_back(std::move(child));
+        return reference;
+    }
+
+    bool Frame::removeChildFrame(const std::string& name) {
+        auto it = std::find_if(m_children.begin(), m_children.end(), [&](const std::unique_ptr<Frame>& frame) {
+            return frame && frame->getName() == name;
+        });
+
+        if (it == m_children.end() || !(*it)->canBeDeleted()) {
+            return false;
+        }
+
+        m_children.erase(it);
+        return true;
+    }
+
+    void Frame::render(TextRenderer& textRenderer) {
+        if (!m_visible) {
+            clearTextBatchesRecursive();
+            return;
+        }
+
+        for (const auto& widget : m_widgets) {
+            if (widget && widget->isVisible()) {
+                widget->render(*this, textRenderer);
+            }
+        }
+
+        const Position basePosition = getAbsolutePosition();
+        for (const auto& command : m_textBatch.getCommands()) {
+            float size = command.sizePixels;
+            if (size <= 0.0f) {
+                size = textRenderer.getBasePixelHeight();
+            }
+
+            textRenderer.renderText(
+                command.text,
+                basePosition.x + command.position.x,
+                basePosition.y + command.position.y,
+                size,
+                command.color);
+        }
+
+        m_textBatch.clear();
+
+        for (auto& child : m_children) {
+            if (child) {
+                child->render(textRenderer);
+            }
+        }
+    }
+
+    void Frame::clearTextBatchesRecursive() {
+        m_textBatch.clear();
+        for (auto& child : m_children) {
+            if (child) {
+                child->clearTextBatchesRecursive();
+            }
+        }
+    }
+
+    void Frame::TextBatch::addText(std::string text, float x, float y, float sizePixels, TextRenderer::Color color) {
+        Command command;
+        command.text = std::move(text);
+        command.position.x = x;
+        command.position.y = y;
+        command.sizePixels = sizePixels;
+        command.color = color;
+        m_commands.emplace_back(std::move(command));
+    }
+
+    void Frame::TextBatch::clear() {
+        m_commands.clear();
+    }
+
+} // namespace WidgeCraft

--- a/src/Widget.cpp
+++ b/src/Widget.cpp
@@ -1,0 +1,81 @@
+#include "WidgeCraft/Widget.hpp"
+
+#include "WidgeCraft/Frame.hpp"
+#include "WidgeCraft/TextRenderer.hpp"
+
+#include <utility>
+
+namespace WidgeCraft {
+
+    Widget::Widget(std::string name)
+        : m_name(std::move(name)) {
+    }
+
+    void Widget::setVisible(bool visible) {
+        m_visible = visible;
+    }
+
+    void Widget::setPosition(float x, float y) {
+        m_position.x = x;
+        m_position.y = y;
+    }
+
+    void Widget::setSize(float width, float height) {
+        m_size.x = width;
+        m_size.y = height;
+    }
+
+    void Widget::setParent(Frame* parent) {
+        m_parent = parent;
+    }
+
+    Widgets::Widgets(Frame& owner)
+        : m_owner(owner) {
+    }
+
+    Label::Label(std::string name, std::string text)
+        : Widget(std::move(name)), m_text(std::move(text)) {
+    }
+
+    void Label::setText(std::string text) {
+        m_text = std::move(text);
+    }
+
+    void Label::render(Frame& frame, TextRenderer& textRenderer) {
+        if (m_text.empty()) {
+            return;
+        }
+
+        float size = m_textSizePixels;
+        if (size <= 0.0f) {
+            size = textRenderer.getBasePixelHeight();
+        }
+
+        const Position position = getPosition();
+        frame.getTextBatch().addText(m_text, position.x, position.y, size, m_color);
+    }
+
+    Button::Button(std::string name, std::string text)
+        : Widget(std::move(name)), m_text(std::move(text)) {
+    }
+
+    void Button::setText(std::string text) {
+        m_text = std::move(text);
+    }
+
+    void Button::render(Frame& frame, TextRenderer& textRenderer) {
+        if (m_text.empty()) {
+            return;
+        }
+
+        float size = m_textSizePixels;
+        if (size <= 0.0f) {
+            size = textRenderer.getBasePixelHeight();
+        }
+
+        const Position position = getPosition();
+        frame.getTextBatch().addText(m_text, position.x, position.y, size, m_textColor);
+    }
+
+} // namespace WidgeCraft
+

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -10,7 +10,10 @@
 namespace WidgeCraft {
 
     Window::Window(int width, int height, const std::string& title)
-        : m_window(nullptr), m_width(width), m_height(height) {
+        : m_window(nullptr)
+        , m_width(width)
+        , m_height(height)
+        , m_rootFrame("Window Frame") {
         if (!glfwInit()) {
             throw std::runtime_error("Failed to initialize GLFW");
         }
@@ -37,6 +40,10 @@ namespace WidgeCraft {
 
         glViewport(0, 0, width, height);
 
+        m_rootFrame.setDeletable(false);
+        m_rootFrame.setPosition(0.0f, 0.0f);
+        m_rootFrame.setSize(static_cast<float>(width), static_cast<float>(height));
+
         std::cout << "Window created: " << title << " (" << width << "x" << height << ")\n";
     }
 
@@ -58,6 +65,7 @@ namespace WidgeCraft {
     void Window::updateSize(int width, int height) {
         m_width = width;
         m_height = height;
+        m_rootFrame.setSize(static_cast<float>(width), static_cast<float>(height));
     }
 
     void Window::framebufferSizeCallback(GLFWwindow* window, int width, int height) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,6 @@
 #include "WidgeCraft/Window.hpp"
+#include "WidgeCraft/Frame.hpp"
+#include "WidgeCraft/Widget.hpp"
 #include "WidgeCraft/TextRenderer.hpp"
 
 // Order matters: glad before glfw
@@ -20,20 +22,40 @@ int main(int argc, char* argv[]) {
         const std::filesystem::path fontPath = std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "fonts/Roboto-Regular.ttf";
         WidgeCraft::TextRenderer textRenderer(window.getWidth(), window.getHeight(), fontPath.string(), 64.0f);
 
+        WidgeCraft::Frame& rootFrame = window.getRootFrame();
+        rootFrame.setBackgroundVisible(false);
+        rootFrame.setBorderVisible(false);
+
+        WidgeCraft::Frame& headerFrame = rootFrame.createChildFrame("Header");
+        headerFrame.setBackgroundVisible(false);
+        headerFrame.setBorderVisible(false);
+
+        auto& titleLabel = headerFrame.addWidget<WidgeCraft::Label>("TitleLabel", "WidgeCraft Engine");
+        auto& actionButton = headerFrame.addWidget<WidgeCraft::Button>("ActionButton", "Start Crafting");
+
+        titleLabel.setColor({ 1.0f, 1.0f, 0.9f });
+        actionButton.setTextColor({ 0.8f, 0.9f, 1.0f });
+        actionButton.setBackgroundVisible(false);
+
+        const float baseTextSize = textRenderer.getBasePixelHeight();
+        titleLabel.setTextSize(baseTextSize);
+        actionButton.setTextSize(baseTextSize * 0.5f);
+
         while (!window.shouldClose()) {
             glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
             glClear(GL_COLOR_BUFFER_BIT);
 
             textRenderer.setScreenSize(window.getWidth(), window.getHeight());
             const float margin = 40.0f;
-            const float textSizePixels = textRenderer.getBasePixelHeight();
-            const float baseline = static_cast<float>(window.getHeight()) - textRenderer.getAscent() - margin;
-            textRenderer.renderText(
-                "Signed Distance Field Text\nRendering from TTF fonts",
-                margin,
-                baseline,
-                textSizePixels,
-                { 1.0f, 1.0f, 1.0f });
+            const float headerHeight = textRenderer.getLineHeight() * 3.0f;
+            headerFrame.setSize(static_cast<float>(window.getWidth()) - margin * 2.0f, headerHeight);
+            headerFrame.setPosition(margin, static_cast<float>(window.getHeight()) - headerHeight - margin);
+
+            const float headerTopBaseline = headerFrame.getSize().y - textRenderer.getAscent() - 10.0f;
+            titleLabel.setPosition(0.0f, headerTopBaseline);
+            actionButton.setPosition(0.0f, headerTopBaseline - textRenderer.getLineHeight());
+
+            rootFrame.render(textRenderer);
 
             glfwSwapBuffers(window.getNativeHandle());
             window.pollEvents();


### PR DESCRIPTION
## Summary
- extract the widget base class, container, and concrete widgets into new Widget headers/sources
- refactor Frame to delegate widget management to the new Widgets container and keep color/background APIs intact
- wire the new module into the build and sample application includes
- add a shared Types header for reusable UI value objects and update Frame/Widget to consume it
- default frames to deletable with an opt-out setter and update the root frame to stay persistent

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d2bcef000c83218c6eded1ad403443