### PR TITLE
Introduce ShapeRenderer class for UI drawing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(widgecraft
     src/main.cpp
     src/Window.cpp
     src/TextRenderer.cpp
+    src/ShapeRenderer.cpp
     src/Frame.cpp
     src/Widget.cpp
 )

--- a/include/WidgeCraft/Frame.hpp
+++ b/include/WidgeCraft/Frame.hpp
@@ -11,6 +11,8 @@
 
 namespace WidgeCraft {
 
+    class ShapeRenderer;
+
     class Frame {
     public:
         class TextBatch {
@@ -61,6 +63,9 @@ namespace WidgeCraft {
         void setSize(const Size& size) { setSize(size.x, size.y); }
         Size getSize() const { return m_size; }
 
+        void setAnchor(Anchor anchor) { m_anchor = anchor; }
+        Anchor getAnchor() const { return m_anchor; }
+
         Position getAbsolutePosition() const;
 
         Frame& createChildFrame(const std::string& name);
@@ -80,10 +85,12 @@ namespace WidgeCraft {
         void setDeletable(bool deletable) { m_deletable = deletable; }
         bool canBeDeleted() const { return m_deletable; }
 
-        void render(TextRenderer& textRenderer);
+        void render(TextRenderer& textRenderer, ShapeRenderer& shapeRenderer);
 
     private:
         void clearTextBatchesRecursive();
+        Frame* getRoot();
+        const Frame* getRoot() const;
 
         std::string m_name;
         Frame* m_parent = nullptr;
@@ -91,9 +98,10 @@ namespace WidgeCraft {
         bool m_showBackground = true;
         bool m_showBorder = false;
         bool m_deletable = true;
-        Color m_backgroundColor{};
-        Position m_position{};
+        Color m_backgroundColor{ Colors::Grey };
+        Position m_position{ 10.0f, 10.0f };
         Size m_size{};
+        Anchor m_anchor = Anchor::Center;
         TextBatch m_textBatch;
         Widgets m_widgets;
         std::vector<std::unique_ptr<Frame>> m_children;

--- a/include/WidgeCraft/ShapeRenderer.hpp
+++ b/include/WidgeCraft/ShapeRenderer.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "WidgeCraft/Types.hpp"
+
+#include <glad/glad.h>
+
+namespace WidgeCraft {
+
+    class ShapeRenderer {
+    public:
+        ShapeRenderer();
+        ~ShapeRenderer();
+
+        ShapeRenderer(const ShapeRenderer&) = delete;
+        ShapeRenderer& operator=(const ShapeRenderer&) = delete;
+        ShapeRenderer(ShapeRenderer&& other) noexcept;
+        ShapeRenderer& operator=(ShapeRenderer&& other) noexcept;
+
+        void setScreenSize(float width, float height);
+
+        void drawFilledRect(float x, float y, float width, float height, const Color& color) const;
+        void drawRectOutline(float x, float y, float width, float height, float thickness, const Color& color) const;
+
+    private:
+        void moveFrom(ShapeRenderer&& other) noexcept;
+        void cleanup();
+
+        GLuint m_vao = 0;
+        GLuint m_vbo = 0;
+        GLuint m_shader = 0;
+        GLint m_uniformScreenSize = -1;
+        GLint m_uniformColor = -1;
+        float m_screenWidth = 0.0f;
+        float m_screenHeight = 0.0f;
+    };
+
+} // namespace WidgeCraft
+

--- a/include/WidgeCraft/TextRenderer.hpp
+++ b/include/WidgeCraft/TextRenderer.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -18,6 +19,13 @@ namespace WidgeCraft {
             float b = 1.0f;
         };
 
+        struct TextBounds {
+            float minX = 0.0f;
+            float minY = 0.0f;
+            float maxX = 0.0f;
+            float maxY = 0.0f;
+        };
+
         TextRenderer(int screenWidth, int screenHeight, const std::string& fontPath, float fontPixelHeight = 48.0f);
         ~TextRenderer();
 
@@ -28,6 +36,8 @@ namespace WidgeCraft {
 
         void setScreenSize(int width, int height);
         void renderText(const std::string& text, float x, float y, float sizePixels = 0.0f, Color color = Color{1.0f, 1.0f, 1.0f});
+
+        std::optional<TextBounds> measureTextBounds(const std::string& text, float sizePixels = 0.0f) const;
 
         float getLineHeight() const { return m_lineHeight; }
         float getAscent() const { return m_ascent; }

--- a/include/WidgeCraft/Types.hpp
+++ b/include/WidgeCraft/Types.hpp
@@ -36,5 +36,26 @@ namespace WidgeCraft {
 
     using Colour = Color;
 
+    namespace Colors {
+        inline constexpr Color Transparent{ 0.0f, 0.0f, 0.0f, 0.0f };
+        inline constexpr Color Black{ 0.0f, 0.0f, 0.0f, 1.0f };
+        inline constexpr Color White{ 1.0f, 1.0f, 1.0f, 1.0f };
+        inline constexpr Color Grey{ 0.5f, 0.5f, 0.5f, 1.0f };
+        inline constexpr Color LightGrey{ 0.75f, 0.75f, 0.75f, 1.0f };
+        inline constexpr Color DarkGrey{ 0.25f, 0.25f, 0.25f, 1.0f };
+        inline constexpr Color Red{ 1.0f, 0.0f, 0.0f, 1.0f };
+        inline constexpr Color Green{ 0.0f, 1.0f, 0.0f, 1.0f };
+        inline constexpr Color Blue{ 0.0f, 0.0f, 1.0f, 1.0f };
+        inline constexpr Color Yellow{ 1.0f, 1.0f, 0.0f, 1.0f };
+        inline constexpr Color Cyan{ 0.0f, 1.0f, 1.0f, 1.0f };
+        inline constexpr Color Magenta{ 1.0f, 0.0f, 1.0f, 1.0f };
+        inline constexpr Color Orange{ 1.0f, 0.5f, 0.0f, 1.0f };
+        inline constexpr Color Purple{ 0.5f, 0.0f, 0.5f, 1.0f };
+    } // namespace Colors
+
+    namespace Colours {
+        using namespace Colors;
+    } // namespace Colours
+
 } // namespace WidgeCraft
 

--- a/include/WidgeCraft/Widget.hpp
+++ b/include/WidgeCraft/Widget.hpp
@@ -11,7 +11,7 @@
 namespace WidgeCraft {
 
     class Frame;
-
+    class ShapeRenderer;
     class Widget {
     public:
         explicit Widget(std::string name);
@@ -29,16 +29,18 @@ namespace WidgeCraft {
         void setSize(float width, float height);
         void setSize(const Size& size) { setSize(size.x, size.y); }
         Size getSize() const { return m_size; }
+        bool hasExplicitSize() const { return m_hasExplicitSize; }
 
         Frame* getParent() const { return m_parent; }
 
-        virtual void render(Frame& frame, TextRenderer& textRenderer) = 0;
+        virtual void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) = 0;
 
         friend class Frame;
         friend class Widgets;
 
     protected:
         void setParent(Frame* parent);
+        void setComputedSize(float width, float height);
 
     private:
         std::string m_name;
@@ -46,6 +48,7 @@ namespace WidgeCraft {
         bool m_visible = true;
         Position m_position{};
         Size m_size{};
+        bool m_hasExplicitSize = false;
     };
 
     class Widgets {
@@ -83,7 +86,7 @@ namespace WidgeCraft {
         void setTextSize(float sizePixels) { m_textSizePixels = sizePixels; }
         float getTextSize() const { return m_textSizePixels; }
 
-        void render(Frame& frame, TextRenderer& textRenderer) override;
+        void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) override;
 
     private:
         std::string m_text;
@@ -110,14 +113,14 @@ namespace WidgeCraft {
         void setBackgroundColor(Color color) { m_backgroundColor = color; }
         Color getBackgroundColor() const { return m_backgroundColor; }
 
-        void render(Frame& frame, TextRenderer& textRenderer) override;
+        void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) override;
 
     private:
         std::string m_text;
         TextRenderer::Color m_textColor{ 1.0f, 1.0f, 1.0f };
         float m_textSizePixels = 0.0f;
         bool m_showBackground = true;
-        Color m_backgroundColor{};
+        Color m_backgroundColor{ Colors::Grey };
     };
 
     template <typename T, typename... Args>

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -1,12 +1,12 @@
 #include "WidgeCraft/Frame.hpp"
 
+#include "WidgeCraft/ShapeRenderer.hpp"
 #include "WidgeCraft/TextRenderer.hpp"
 
 #include <algorithm>
 #include <utility>
 
 namespace WidgeCraft {
-
     Frame::Frame(std::string name, Frame* parent)
         : m_name(std::move(name)), m_parent(parent), m_widgets(*this) {
     }
@@ -38,7 +38,49 @@ namespace WidgeCraft {
         }
 
         const Position parentPosition = m_parent->getAbsolutePosition();
-        return { parentPosition.x + m_position.x, parentPosition.y + m_position.y };
+        const Size parentSize = m_parent->getSize();
+        Position result = parentPosition;
+
+        switch (m_anchor) {
+        case Anchor::TopLeft:
+            result.x += m_position.x;
+            result.y += parentSize.y - m_position.y - m_size.y;
+            break;
+        case Anchor::TopCenter:
+            result.x += (parentSize.x - m_size.x) * 0.5f + m_position.x;
+            result.y += parentSize.y - m_position.y - m_size.y;
+            break;
+        case Anchor::TopRight:
+            result.x += parentSize.x - m_position.x - m_size.x;
+            result.y += parentSize.y - m_position.y - m_size.y;
+            break;
+        case Anchor::CenterLeft:
+            result.x += m_position.x;
+            result.y += (parentSize.y - m_size.y) * 0.5f + m_position.y;
+            break;
+        case Anchor::Center:
+            result.x += (parentSize.x - m_size.x) * 0.5f;
+            result.y += (parentSize.y - m_size.y) * 0.5f;
+            break;
+        case Anchor::CenterRight:
+            result.x += parentSize.x - m_position.x - m_size.x;
+            result.y += (parentSize.y - m_size.y) * 0.5f + m_position.y;
+            break;
+        case Anchor::BottomLeft:
+            result.x += m_position.x;
+            result.y += m_position.y;
+            break;
+        case Anchor::BottomCenter:
+            result.x += (parentSize.x - m_size.x) * 0.5f + m_position.x;
+            result.y += m_position.y;
+            break;
+        case Anchor::BottomRight:
+            result.x += parentSize.x - m_position.x - m_size.x;
+            result.y += m_position.y;
+            break;
+        }
+
+        return result;
     }
 
     Frame& Frame::createChildFrame(const std::string& name) {
@@ -61,19 +103,23 @@ namespace WidgeCraft {
         return true;
     }
 
-    void Frame::render(TextRenderer& textRenderer) {
+    void Frame::render(TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) {
         if (!m_visible) {
             clearTextBatchesRecursive();
             return;
         }
 
+        const Position basePosition = getAbsolutePosition();
+        if (m_showBackground && m_size.x > 0.0f && m_size.y > 0.0f) {
+            shapeRenderer.drawFilledRect(basePosition.x, basePosition.y, m_size.x, m_size.y, m_backgroundColor);
+        }
+
         for (const auto& widget : m_widgets) {
             if (widget && widget->isVisible()) {
-                widget->render(*this, textRenderer);
+                widget->render(*this, textRenderer, shapeRenderer);
             }
         }
 
-        const Position basePosition = getAbsolutePosition();
         for (const auto& command : m_textBatch.getCommands()) {
             float size = command.sizePixels;
             if (size <= 0.0f) {
@@ -92,8 +138,12 @@ namespace WidgeCraft {
 
         for (auto& child : m_children) {
             if (child) {
-                child->render(textRenderer);
+                child->render(textRenderer, shapeRenderer);
             }
+        }
+
+        if (m_showBorder && m_size.x > 0.0f && m_size.y > 0.0f) {
+            shapeRenderer.drawRectOutline(basePosition.x, basePosition.y, m_size.x, m_size.y, 2.0f, Colors::Black);
         }
     }
 
@@ -104,6 +154,22 @@ namespace WidgeCraft {
                 child->clearTextBatchesRecursive();
             }
         }
+    }
+
+    Frame* Frame::getRoot() {
+        Frame* current = this;
+        while (current && current->m_parent) {
+            current = current->m_parent;
+        }
+        return current;
+    }
+
+    const Frame* Frame::getRoot() const {
+        const Frame* current = this;
+        while (current && current->m_parent) {
+            current = current->m_parent;
+        }
+        return current;
     }
 
     void Frame::TextBatch::addText(std::string text, float x, float y, float sizePixels, TextRenderer::Color color) {

--- a/src/ShapeRenderer.cpp
+++ b/src/ShapeRenderer.cpp
@@ -1,0 +1,194 @@
+#include "WidgeCraft/ShapeRenderer.hpp"
+
+#include <algorithm>
+#include <array>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+    GLuint compileShader(GLenum type, const char* source) {
+        GLuint shader = glCreateShader(type);
+        glShaderSource(shader, 1, &source, nullptr);
+        glCompileShader(shader);
+
+        GLint status = 0;
+        glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
+        if (status == GL_FALSE) {
+            GLint logLength = 0;
+            glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
+            std::string log(static_cast<size_t>(logLength > 0 ? logLength : 1), '\0');
+            glGetShaderInfoLog(shader, logLength, nullptr, log.data());
+            glDeleteShader(shader);
+            throw std::runtime_error("Failed to compile rectangle shader: " + log);
+        }
+
+        return shader;
+    }
+
+    GLuint linkProgram(GLuint vertexShader, GLuint fragmentShader) {
+        GLuint program = glCreateProgram();
+        glAttachShader(program, vertexShader);
+        glAttachShader(program, fragmentShader);
+        glLinkProgram(program);
+
+        GLint status = 0;
+        glGetProgramiv(program, GL_LINK_STATUS, &status);
+        if (status == GL_FALSE) {
+            GLint logLength = 0;
+            glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
+            std::string log(static_cast<size_t>(logLength > 0 ? logLength : 1), '\0');
+            glGetProgramInfoLog(program, logLength, nullptr, log.data());
+            glDeleteProgram(program);
+            throw std::runtime_error("Failed to link rectangle shader: " + log);
+        }
+
+        return program;
+    }
+
+} // namespace
+
+namespace WidgeCraft {
+
+    ShapeRenderer::ShapeRenderer() {
+        static constexpr char kVertexShaderSrc[] = R"(
+            #version 330 core
+            layout (location = 0) in vec2 aPos;
+
+            uniform vec2 uScreenSize;
+
+            void main() {
+                vec2 normalized = vec2(
+                    (aPos.x / uScreenSize.x) * 2.0 - 1.0,
+                    (aPos.y / uScreenSize.y) * 2.0 - 1.0
+                );
+                gl_Position = vec4(normalized, 0.0, 1.0);
+            }
+        )";
+
+        static constexpr char kFragmentShaderSrc[] = R"(
+            #version 330 core
+            uniform vec4 uColor;
+            out vec4 FragColor;
+
+            void main() {
+                FragColor = uColor;
+            }
+        )";
+
+        const GLuint vertexShader = compileShader(GL_VERTEX_SHADER, kVertexShaderSrc);
+        const GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, kFragmentShaderSrc);
+        m_shader = linkProgram(vertexShader, fragmentShader);
+        glDeleteShader(vertexShader);
+        glDeleteShader(fragmentShader);
+
+        glGenVertexArrays(1, &m_vao);
+        glGenBuffers(1, &m_vbo);
+
+        glBindVertexArray(m_vao);
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 8, nullptr, GL_DYNAMIC_DRAW);
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 2, reinterpret_cast<void*>(0));
+        glBindVertexArray(0);
+
+        m_uniformScreenSize = glGetUniformLocation(m_shader, "uScreenSize");
+        m_uniformColor = glGetUniformLocation(m_shader, "uColor");
+    }
+
+    ShapeRenderer::~ShapeRenderer() {
+        cleanup();
+    }
+
+    ShapeRenderer::ShapeRenderer(ShapeRenderer&& other) noexcept {
+        moveFrom(std::move(other));
+    }
+
+    ShapeRenderer& ShapeRenderer::operator=(ShapeRenderer&& other) noexcept {
+        if (this != &other) {
+            cleanup();
+            moveFrom(std::move(other));
+        }
+        return *this;
+    }
+
+    void ShapeRenderer::moveFrom(ShapeRenderer&& other) noexcept {
+        m_vao = other.m_vao;
+        m_vbo = other.m_vbo;
+        m_shader = other.m_shader;
+        m_uniformScreenSize = other.m_uniformScreenSize;
+        m_uniformColor = other.m_uniformColor;
+        m_screenWidth = other.m_screenWidth;
+        m_screenHeight = other.m_screenHeight;
+
+        other.m_vao = 0;
+        other.m_vbo = 0;
+        other.m_shader = 0;
+        other.m_uniformScreenSize = -1;
+        other.m_uniformColor = -1;
+        other.m_screenWidth = 0.0f;
+        other.m_screenHeight = 0.0f;
+    }
+
+    void ShapeRenderer::cleanup() {
+        if (m_vbo != 0) {
+            glDeleteBuffers(1, &m_vbo);
+            m_vbo = 0;
+        }
+        if (m_vao != 0) {
+            glDeleteVertexArrays(1, &m_vao);
+            m_vao = 0;
+        }
+        if (m_shader != 0) {
+            glDeleteProgram(m_shader);
+            m_shader = 0;
+        }
+        m_uniformScreenSize = -1;
+        m_uniformColor = -1;
+        m_screenWidth = 0.0f;
+        m_screenHeight = 0.0f;
+    }
+
+    void ShapeRenderer::setScreenSize(float width, float height) {
+        m_screenWidth = width;
+        m_screenHeight = height;
+    }
+
+    void ShapeRenderer::drawFilledRect(float x, float y, float width, float height, const Color& color) const {
+        if (width <= 0.0f || height <= 0.0f || m_screenWidth <= 0.0f || m_screenHeight <= 0.0f) {
+            return;
+        }
+
+        const std::array<float, 8> vertices{
+            x, y,
+            x + width, y,
+            x, y + height,
+            x + width, y + height,
+        };
+
+        glUseProgram(m_shader);
+        glUniform2f(m_uniformScreenSize, m_screenWidth, m_screenHeight);
+        glUniform4f(m_uniformColor, color.r, color.g, color.b, color.a);
+
+        glBindVertexArray(m_vao);
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices.data());
+        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+        glBindVertexArray(0);
+    }
+
+    void ShapeRenderer::drawRectOutline(float x, float y, float width, float height, float thickness, const Color& color) const {
+        if (width <= 0.0f || height <= 0.0f || thickness <= 0.0f) {
+            return;
+        }
+
+        const float clampedThickness = std::min(thickness, std::min(width, height));
+
+        drawFilledRect(x, y, width, clampedThickness, color);
+        drawFilledRect(x, y + height - clampedThickness, width, clampedThickness, color);
+        drawFilledRect(x, y, clampedThickness, height, color);
+        drawFilledRect(x + width - clampedThickness, y, clampedThickness, height, color);
+    }
+
+} // namespace WidgeCraft
+

--- a/src/TextRenderer.cpp
+++ b/src/TextRenderer.cpp
@@ -3,6 +3,7 @@
 #include <glad/glad.h>
 
 #include <algorithm>
+#include <limits>
 #include <fstream>
 #include <stdexcept>
 #include <string>
@@ -311,6 +312,121 @@ namespace WidgeCraft {
         glBindVertexArray(0);
         glBindTexture(GL_TEXTURE_2D, 0);
         glUseProgram(0);
+    }
+
+    std::optional<TextRenderer::TextBounds> TextRenderer::measureTextBounds(const std::string& text, float sizePixels) const {
+        if (text.empty() || m_basePixelHeight <= 0.0f) {
+            return std::nullopt;
+        }
+
+        if (sizePixels <= 0.0f) {
+            sizePixels = m_basePixelHeight;
+        }
+
+        if (sizePixels <= 0.0f) {
+            return std::nullopt;
+        }
+
+        const float sizeScale = sizePixels / m_basePixelHeight;
+
+        float cursorX = 0.0f;
+        float cursorY = 0.0f;
+        float lowestBaseline = 0.0f;
+        float maxLineWidth = 0.0f;
+        bool hasGeometry = false;
+
+        float minX = std::numeric_limits<float>::max();
+        float minY = std::numeric_limits<float>::max();
+        float maxX = std::numeric_limits<float>::lowest();
+        float maxY = std::numeric_limits<float>::lowest();
+
+        for (size_t i = 0; i < text.size(); ++i) {
+            const char c = text[i];
+            if (c == '\n') {
+                maxLineWidth = std::max(maxLineWidth, cursorX);
+                cursorX = 0.0f;
+                cursorY -= m_lineHeight * sizeScale;
+                lowestBaseline = std::min(lowestBaseline, cursorY);
+                continue;
+            }
+
+            const Glyph* glyph = nullptr;
+            if (auto it = m_glyphs.find(c); it != m_glyphs.end()) {
+                glyph = &it->second;
+            } else {
+                glyph = m_fallbackGlyph;
+            }
+
+            if (!glyph) {
+                continue;
+            }
+
+            const float xPos = cursorX + glyph->xOffset * sizeScale;
+            const float yPos = cursorY - (glyph->yOffset + glyph->height) * sizeScale;
+            const float w = glyph->width * sizeScale;
+            const float h = glyph->height * sizeScale;
+
+            if (w > 0.0f && h > 0.0f) {
+                hasGeometry = true;
+                minX = std::min(minX, xPos);
+                minY = std::min(minY, yPos);
+                maxX = std::max(maxX, xPos + w);
+                maxY = std::max(maxY, yPos + h);
+            }
+
+            cursorX += glyph->advance * sizeScale;
+            maxLineWidth = std::max(maxLineWidth, cursorX);
+
+            if (i + 1 < text.size()) {
+                const char nextChar = text[i + 1];
+                if (nextChar != '\n') {
+                    int nextGlyphIndex = 0;
+                    if (auto itNext = m_glyphs.find(nextChar); itNext != m_glyphs.end()) {
+                        nextGlyphIndex = itNext->second.glyphIndex;
+                    } else if (m_fallbackGlyph) {
+                        nextGlyphIndex = m_fallbackGlyph->glyphIndex;
+                    }
+
+                    if (glyph->glyphIndex >= 0 && nextGlyphIndex >= 0) {
+                        int kern = stbtt_GetGlyphKernAdvance(m_fontInfo.get(), glyph->glyphIndex, nextGlyphIndex);
+                        cursorX += static_cast<float>(kern) * m_scale * sizeScale;
+                        maxLineWidth = std::max(maxLineWidth, cursorX);
+                    }
+                }
+            }
+        }
+
+        maxLineWidth = std::max(maxLineWidth, cursorX);
+
+        if (!hasGeometry) {
+            if (maxLineWidth <= 0.0f) {
+                return std::nullopt;
+            }
+
+            minX = 0.0f;
+            maxX = maxLineWidth;
+        } else {
+            minX = std::min(minX, 0.0f);
+            maxX = std::max(maxX, maxLineWidth);
+        }
+
+        const float top = m_ascent * sizeScale;
+        const float bottom = lowestBaseline + m_descent * sizeScale;
+
+        if (!hasGeometry) {
+            minY = bottom;
+            maxY = top;
+        } else {
+            minY = std::min(minY, bottom);
+            maxY = std::max(maxY, top);
+        }
+
+        TextBounds bounds{};
+        bounds.minX = minX;
+        bounds.minY = minY;
+        bounds.maxX = maxX;
+        bounds.maxY = maxY;
+        return bounds;
     }
 
     bool TextRenderer::loadFont(const std::string& fontPath) {

--- a/src/Widget.cpp
+++ b/src/Widget.cpp
@@ -1,8 +1,10 @@
 #include "WidgeCraft/Widget.hpp"
 
 #include "WidgeCraft/Frame.hpp"
+#include "WidgeCraft/ShapeRenderer.hpp"
 #include "WidgeCraft/TextRenderer.hpp"
 
+#include <algorithm>
 #include <utility>
 
 namespace WidgeCraft {
@@ -23,10 +25,16 @@ namespace WidgeCraft {
     void Widget::setSize(float width, float height) {
         m_size.x = width;
         m_size.y = height;
+        m_hasExplicitSize = true;
     }
 
     void Widget::setParent(Frame* parent) {
         m_parent = parent;
+    }
+
+    void Widget::setComputedSize(float width, float height) {
+        m_size.x = width;
+        m_size.y = height;
     }
 
     Widgets::Widgets(Frame& owner)
@@ -41,18 +49,58 @@ namespace WidgeCraft {
         m_text = std::move(text);
     }
 
-    void Label::render(Frame& frame, TextRenderer& textRenderer) {
-        if (m_text.empty()) {
-            return;
-        }
-
+    void Label::render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) {
         float size = m_textSizePixels;
         if (size <= 0.0f) {
             size = textRenderer.getBasePixelHeight();
         }
 
         const Position position = getPosition();
-        frame.getTextBatch().addText(m_text, position.x, position.y, size, m_color);
+        float offsetX = 0.0f;
+        float offsetY = 0.0f;
+        float boundsWidth = 0.0f;
+        float boundsHeight = 0.0f;
+        bool haveBounds = false;
+
+        if (!m_text.empty()) {
+            if (auto bounds = textRenderer.measureTextBounds(m_text, size)) {
+                boundsWidth = bounds->maxX - bounds->minX;
+                boundsHeight = bounds->maxY - bounds->minY;
+                offsetX = bounds->minX;
+                offsetY = bounds->minY;
+                haveBounds = true;
+            }
+        }
+
+        float finalWidth = boundsWidth;
+        float finalHeight = boundsHeight;
+
+        if (hasExplicitSize()) {
+            const Size explicitSize = getSize();
+            if (explicitSize.x > 0.0f) {
+                finalWidth = std::max(finalWidth, explicitSize.x);
+            }
+            if (explicitSize.y > 0.0f) {
+                finalHeight = std::max(finalHeight, explicitSize.y);
+            }
+        } else {
+            if (finalWidth <= 0.0f) {
+                finalWidth = size;
+            }
+            if (finalHeight <= 0.0f) {
+                finalHeight = size;
+            }
+        }
+
+        const Position framePosition = frame.getAbsolutePosition();
+        const float borderX = framePosition.x + position.x + (haveBounds ? offsetX : 0.0f);
+        const float borderY = framePosition.y + position.y + (haveBounds ? offsetY : 0.0f);
+        shapeRenderer.drawRectOutline(borderX, borderY, finalWidth, finalHeight, 1.0f, Colors::Black);
+        setComputedSize(finalWidth, finalHeight);
+
+        if (!m_text.empty()) {
+            frame.getTextBatch().addText(m_text, position.x, position.y, size, m_color);
+        }
     }
 
     Button::Button(std::string name, std::string text)
@@ -63,18 +111,63 @@ namespace WidgeCraft {
         m_text = std::move(text);
     }
 
-    void Button::render(Frame& frame, TextRenderer& textRenderer) {
-        if (m_text.empty()) {
-            return;
-        }
-
+    void Button::render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) {
         float size = m_textSizePixels;
         if (size <= 0.0f) {
             size = textRenderer.getBasePixelHeight();
         }
 
         const Position position = getPosition();
-        frame.getTextBatch().addText(m_text, position.x, position.y, size, m_textColor);
+        float offsetX = 0.0f;
+        float offsetY = 0.0f;
+        float boundsWidth = 0.0f;
+        float boundsHeight = 0.0f;
+        bool haveBounds = false;
+
+        if (!m_text.empty()) {
+            if (auto bounds = textRenderer.measureTextBounds(m_text, size)) {
+                boundsWidth = bounds->maxX - bounds->minX;
+                boundsHeight = bounds->maxY - bounds->minY;
+                offsetX = bounds->minX;
+                offsetY = bounds->minY;
+                haveBounds = true;
+            }
+        }
+
+        float finalWidth = boundsWidth;
+        float finalHeight = boundsHeight;
+
+        if (hasExplicitSize()) {
+            const Size explicitSize = getSize();
+            if (explicitSize.x > 0.0f) {
+                finalWidth = std::max(finalWidth, explicitSize.x);
+            }
+            if (explicitSize.y > 0.0f) {
+                finalHeight = std::max(finalHeight, explicitSize.y);
+            }
+        } else {
+            if (finalWidth <= 0.0f) {
+                finalWidth = size;
+            }
+            if (finalHeight <= 0.0f) {
+                finalHeight = size;
+            }
+        }
+
+        const Position framePosition = frame.getAbsolutePosition();
+        const float rectX = framePosition.x + position.x + (haveBounds ? offsetX : 0.0f);
+        const float rectY = framePosition.y + position.y + (haveBounds ? offsetY : 0.0f);
+
+        if (m_showBackground) {
+            shapeRenderer.drawFilledRect(rectX, rectY, finalWidth, finalHeight, m_backgroundColor);
+        }
+
+        shapeRenderer.drawRectOutline(rectX, rectY, finalWidth, finalHeight, 1.0f, Colors::Black);
+        setComputedSize(finalWidth, finalHeight);
+
+        if (!m_text.empty()) {
+            frame.getTextBatch().addText(m_text, position.x, position.y, size, m_textColor);
+        }
     }
 
 } // namespace WidgeCraft

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -41,6 +41,10 @@ namespace WidgeCraft {
         glViewport(0, 0, width, height);
 
         m_rootFrame.setDeletable(false);
+        m_rootFrame.setAnchor(Anchor::TopLeft);
+        m_rootFrame.setBackgroundColor(Colors::DarkGrey);
+        m_rootFrame.setBorderVisible(false);
+        m_rootFrame.setBackgroundVisible(true);
         m_rootFrame.setPosition(0.0f, 0.0f);
         m_rootFrame.setSize(static_cast<float>(width), static_cast<float>(height));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "WidgeCraft/Window.hpp"
 #include "WidgeCraft/Frame.hpp"
+#include "WidgeCraft/ShapeRenderer.hpp"
 #include "WidgeCraft/Widget.hpp"
 #include "WidgeCraft/TextRenderer.hpp"
 
@@ -21,9 +22,8 @@ int main(int argc, char* argv[]) {
 
         const std::filesystem::path fontPath = std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "fonts/Roboto-Regular.ttf";
         WidgeCraft::TextRenderer textRenderer(window.getWidth(), window.getHeight(), fontPath.string(), 64.0f);
-
+        WidgeCraft::ShapeRenderer shapeRenderer;
         WidgeCraft::Frame& rootFrame = window.getRootFrame();
-        rootFrame.setBackgroundVisible(false);
         rootFrame.setBorderVisible(false);
 
         WidgeCraft::Frame& headerFrame = rootFrame.createChildFrame("Header");
@@ -46,6 +46,7 @@ int main(int argc, char* argv[]) {
             glClear(GL_COLOR_BUFFER_BIT);
 
             textRenderer.setScreenSize(window.getWidth(), window.getHeight());
+            shapeRenderer.setScreenSize(static_cast<float>(window.getWidth()), static_cast<float>(window.getHeight()));
             const float margin = 40.0f;
             const float headerHeight = textRenderer.getLineHeight() * 3.0f;
             headerFrame.setSize(static_cast<float>(window.getWidth()) - margin * 2.0f, headerHeight);
@@ -55,7 +56,7 @@ int main(int argc, char* argv[]) {
             titleLabel.setPosition(0.0f, headerTopBaseline);
             actionButton.setPosition(0.0f, headerTopBaseline - textRenderer.getLineHeight());
 
-            rootFrame.render(textRenderer);
+            rootFrame.render(textRenderer, shapeRenderer);
 
             glfwSwapBuffers(window.getNativeHandle());
             window.pollEvents();


### PR DESCRIPTION
## Summary
- replace the old RenderPrimitives helpers with a dedicated ShapeRenderer class for filling and outlining rectangles
- update frames and widgets to consume ShapeRenderer so backgrounds and borders render before text
- wire ShapeRenderer into the main loop and build so it keeps window-relative sizing up to date

## Testing
- cmake -S . -B build *(fails: RandR headers not found; install libxrandr development package)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b4d6d0f08321ad25a337fed35498