### PR TITLE
Add WidgeCraft application wrapper class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(widgecraft
     src/ShapeRenderer.cpp
     src/Frame.cpp
     src/Widget.cpp
+    src/WidgeCraft.cpp
 )
 
 target_include_directories(widgecraft

--- a/include/WidgeCraft/WidgeCraft.hpp
+++ b/include/WidgeCraft/WidgeCraft.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "WidgeCraft/ShapeRenderer.hpp"
+#include "WidgeCraft/TextRenderer.hpp"
+#include "WidgeCraft/Types.hpp"
+#include "WidgeCraft/Window.hpp"
+
+#include <functional>
+#include <string>
+
+namespace WidgeCraft {
+
+    class WidgeCraft {
+    public:
+        using UpdateCallback = std::function<void(WidgeCraft&)>;
+        using RenderCallback = std::function<void(WidgeCraft&)>;
+
+        WidgeCraft(std::string title, int width, int height, std::string fontPath = {}, float fontPixelHeight = 64.0f);
+        ~WidgeCraft() = default;
+
+        WidgeCraft(const WidgeCraft&) = delete;
+        WidgeCraft& operator=(const WidgeCraft&) = delete;
+        WidgeCraft(WidgeCraft&&) noexcept = default;
+        WidgeCraft& operator=(WidgeCraft&&) noexcept = default;
+
+        void Run();
+
+        void Update();
+        void Render();
+
+        void setUpdateCallback(UpdateCallback callback) { m_updateCallback = std::move(callback); }
+        void setRenderCallback(RenderCallback callback) { m_renderCallback = std::move(callback); }
+
+        void setClearColor(Color color) { m_clearColor = color; }
+        Color getClearColor() const { return m_clearColor; }
+
+        Window& getWindow() { return m_window; }
+        const Window& getWindow() const { return m_window; }
+
+        Frame& getRootFrame() { return m_window.getRootFrame(); }
+        const Frame& getRootFrame() const { return m_window.getRootFrame(); }
+
+        TextRenderer& getTextRenderer() { return m_textRenderer; }
+        const TextRenderer& getTextRenderer() const { return m_textRenderer; }
+
+        ShapeRenderer& getShapeRenderer() { return m_shapeRenderer; }
+        const ShapeRenderer& getShapeRenderer() const { return m_shapeRenderer; }
+
+    private:
+        void initializeGraphics();
+        static std::string resolveFontPath(const std::string& fontPath);
+
+        Window m_window;
+        TextRenderer m_textRenderer;
+        ShapeRenderer m_shapeRenderer;
+        Color m_clearColor{ 0.2f, 0.3f, 0.3f, 1.0f };
+        UpdateCallback m_updateCallback;
+        RenderCallback m_renderCallback;
+    };
+
+} // namespace WidgeCraft
+

--- a/src/WidgeCraft.cpp
+++ b/src/WidgeCraft.cpp
@@ -1,0 +1,73 @@
+#include "WidgeCraft/WidgeCraft.hpp"
+
+#include "WidgeCraft/ShapeRenderer.hpp"
+#include "WidgeCraft/TextRenderer.hpp"
+
+// Order matters: glad before glfw
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+#include <filesystem>
+#include <utility>
+
+namespace WidgeCraft {
+
+    namespace {
+        std::string resolveDefaultFontPath() {
+            const std::filesystem::path defaultPath = std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "fonts/Roboto-Regular.ttf";
+            return defaultPath.string();
+        }
+    }
+
+    WidgeCraft::WidgeCraft(std::string title, int width, int height, std::string fontPath, float fontPixelHeight)
+        : m_window(width, height, std::move(title))
+        , m_textRenderer(m_window.getWidth(), m_window.getHeight(), resolveFontPath(fontPath), fontPixelHeight)
+        , m_shapeRenderer() {
+        initializeGraphics();
+    }
+
+    void WidgeCraft::Run() {
+        while (!m_window.shouldClose()) {
+            Update();
+            Render();
+
+            glfwSwapBuffers(m_window.getNativeHandle());
+            m_window.pollEvents();
+        }
+    }
+
+    void WidgeCraft::Update() {
+        m_textRenderer.setScreenSize(m_window.getWidth(), m_window.getHeight());
+        m_shapeRenderer.setScreenSize(static_cast<float>(m_window.getWidth()), static_cast<float>(m_window.getHeight()));
+
+        if (m_updateCallback) {
+            m_updateCallback(*this);
+        }
+    }
+
+    void WidgeCraft::Render() {
+        glClearColor(m_clearColor.r, m_clearColor.g, m_clearColor.b, m_clearColor.a);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        if (m_renderCallback) {
+            m_renderCallback(*this);
+        }
+
+        m_window.getRootFrame().render(m_textRenderer, m_shapeRenderer);
+    }
+
+    void WidgeCraft::initializeGraphics() {
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    }
+
+    std::string WidgeCraft::resolveFontPath(const std::string& fontPath) {
+        if (!fontPath.empty()) {
+            return fontPath;
+        }
+
+        return resolveDefaultFontPath();
+    }
+
+} // namespace WidgeCraft
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,29 +1,16 @@
-#include "WidgeCraft/Window.hpp"
-#include "WidgeCraft/Frame.hpp"
-#include "WidgeCraft/ShapeRenderer.hpp"
+#include "WidgeCraft/WidgeCraft.hpp"
 #include "WidgeCraft/Widget.hpp"
-#include "WidgeCraft/TextRenderer.hpp"
 
-// Order matters: glad before glfw
-#include <glad/glad.h>
-#include <GLFW/glfw3.h>
-
-#include <filesystem>
 #include <iostream>
-#include <string>
 
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;
-    try {
-        WidgeCraft::Window window(800, 600, "WidgeCraft Engine");
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-        const std::filesystem::path fontPath = std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "fonts/Roboto-Regular.ttf";
-        WidgeCraft::TextRenderer textRenderer(window.getWidth(), window.getHeight(), fontPath.string(), 64.0f);
-        WidgeCraft::ShapeRenderer shapeRenderer;
-        WidgeCraft::Frame& rootFrame = window.getRootFrame();
+    try {
+        WidgeCraft::WidgeCraft wc("WidgeCraft Engine", 800, 600);
+
+        WidgeCraft::Frame& rootFrame = wc.getRootFrame();
         rootFrame.setBorderVisible(false);
 
         WidgeCraft::Frame& headerFrame = rootFrame.createChildFrame("Header");
@@ -37,16 +24,14 @@ int main(int argc, char* argv[]) {
         actionButton.setTextColor({ 0.8f, 0.9f, 1.0f });
         actionButton.setBackgroundVisible(false);
 
-        const float baseTextSize = textRenderer.getBasePixelHeight();
+        const float baseTextSize = wc.getTextRenderer().getBasePixelHeight();
         titleLabel.setTextSize(baseTextSize);
         actionButton.setTextSize(baseTextSize * 0.5f);
 
-        while (!window.shouldClose()) {
-            glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
-            glClear(GL_COLOR_BUFFER_BIT);
+        wc.setUpdateCallback([&](WidgeCraft::WidgeCraft& app) {
+            auto& window = app.getWindow();
+            auto& textRenderer = app.getTextRenderer();
 
-            textRenderer.setScreenSize(window.getWidth(), window.getHeight());
-            shapeRenderer.setScreenSize(static_cast<float>(window.getWidth()), static_cast<float>(window.getHeight()));
             const float margin = 40.0f;
             const float headerHeight = textRenderer.getLineHeight() * 3.0f;
             headerFrame.setSize(static_cast<float>(window.getWidth()) - margin * 2.0f, headerHeight);
@@ -55,12 +40,9 @@ int main(int argc, char* argv[]) {
             const float headerTopBaseline = headerFrame.getSize().y - textRenderer.getAscent() - 10.0f;
             titleLabel.setPosition(0.0f, headerTopBaseline);
             actionButton.setPosition(0.0f, headerTopBaseline - textRenderer.getLineHeight());
+        });
 
-            rootFrame.render(textRenderer, shapeRenderer);
-
-            glfwSwapBuffers(window.getNativeHandle());
-            window.pollEvents();
-        }
+        wc.Run();
     }
     catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << "\n";
@@ -70,3 +52,4 @@ int main(int argc, char* argv[]) {
 
     return 0;
 }
+


### PR DESCRIPTION
## Summary
- add a WidgeCraft application wrapper that owns the window, renderers, and render/update loop
- simplify `main.cpp` to configure frames/widgets before delegating to the wrapper to run
- register the new application source file with CMake

## Testing
- cmake -S . -B build *(fails: RandR headers not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cae2267c83218ddaad90f0ada44d