### PR TITLE
Refine WidgeCraft API for frame and widget management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(widgecraft
     src/ShapeRenderer.cpp
     src/Frame.cpp
     src/Widget.cpp
+    src/WidgeCraft.cpp
 )
 
 target_include_directories(widgecraft

--- a/include/WidgeCraft/WidgeCraft.hpp
+++ b/include/WidgeCraft/WidgeCraft.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "WidgeCraft/ShapeRenderer.hpp"
+#include "WidgeCraft/TextRenderer.hpp"
+#include "WidgeCraft/Types.hpp"
+#include "WidgeCraft/Widget.hpp"
+#include "WidgeCraft/Window.hpp"
+
+#include <functional>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace WidgeCraft {
+
+    class WidgeCraft {
+    public:
+        using StartupCallback = std::function<void(WidgeCraft&)>;
+        using UpdateCallback = std::function<void(WidgeCraft&)>;
+        using RenderCallback = std::function<void(WidgeCraft&)>;
+        using ExitCallback = std::function<void(WidgeCraft&)>;
+
+        WidgeCraft(std::string title, int width, int height, std::string fontPath = {}, float fontPixelHeight = 64.0f);
+        ~WidgeCraft();
+
+        WidgeCraft(const WidgeCraft&) = delete;
+        WidgeCraft& operator=(const WidgeCraft&) = delete;
+        WidgeCraft(WidgeCraft&&) noexcept = default;
+        WidgeCraft& operator=(WidgeCraft&&) noexcept = default;
+
+        void onStartup(StartupCallback callback);
+
+        void onUpdate(UpdateCallback callback);
+        void onUpdate();
+
+        void onRender(RenderCallback callback) { m_renderCallback = std::move(callback); }
+
+        void onExit(ExitCallback callback) { m_exitCallback = std::move(callback); }
+        void onExit();
+
+        void setClearColor(Color color) { m_clearColor = color; }
+        Color getClearColor() const { return m_clearColor; }
+
+        bool shouldClose() const { return m_window.shouldClose(); }
+
+        Window& getWindow() { return m_window; }
+        const Window& getWindow() const { return m_window; }
+
+        Frame& getRootFrame() { return m_window.getRootFrame(); }
+        const Frame& getRootFrame() const { return m_window.getRootFrame(); }
+
+        const std::string& getRootFrameName() const { return m_rootFrameName; }
+
+        TextRenderer& getTextRenderer() { return m_textRenderer; }
+        const TextRenderer& getTextRenderer() const { return m_textRenderer; }
+
+        ShapeRenderer& getShapeRenderer() { return m_shapeRenderer; }
+        const ShapeRenderer& getShapeRenderer() const { return m_shapeRenderer; }
+
+        Frame& addFrame(const std::string& frameName, const std::string& parentFrameName = {});
+        bool removeFrame(const std::string& frameName);
+
+        void frameSetVisible(const std::string& frameName, bool visible);
+        void frameSetBackgroundVisible(const std::string& frameName, bool visible);
+        void frameSetBorderVisible(const std::string& frameName, bool visible);
+        void frameSetBackgroundColor(const std::string& frameName, Color color);
+        void frameSetPosition(const std::string& frameName, float x, float y);
+        void frameSetPosition(const std::string& frameName, const Position& position) { frameSetPosition(frameName, position.x, position.y); }
+        void frameSetSize(const std::string& frameName, float width, float height);
+        void frameSetSize(const std::string& frameName, const Size& size) { frameSetSize(frameName, size.x, size.y); }
+        void frameSetAnchor(const std::string& frameName, Anchor anchor);
+
+        Position frameGetPosition(const std::string& frameName) const;
+        Size frameGetSize(const std::string& frameName) const;
+
+        Label& addLabel(const std::string& frameName, const std::string& widgetName, std::string text = {});
+        Button& addButton(const std::string& frameName, const std::string& widgetName, std::string text = {});
+        bool removeWidget(const std::string& frameName, const std::string& widgetName);
+
+        void widgetSetVisible(const std::string& frameName, const std::string& widgetName, bool visible);
+        void widgetSetPosition(const std::string& frameName, const std::string& widgetName, float x, float y);
+        void widgetSetPosition(const std::string& frameName, const std::string& widgetName, const Position& position) { widgetSetPosition(frameName, widgetName, position.x, position.y); }
+        void widgetSetSize(const std::string& frameName, const std::string& widgetName, float width, float height);
+        void widgetSetSize(const std::string& frameName, const std::string& widgetName, const Size& size) { widgetSetSize(frameName, widgetName, size.x, size.y); }
+        void widgetSetText(const std::string& frameName, const std::string& widgetName, const std::string& text);
+        void widgetSetTextSize(const std::string& frameName, const std::string& widgetName, float sizePixels);
+        void widgetSetColor(const std::string& frameName, const std::string& widgetName, TextRenderer::Color color);
+        void widgetSetTextColor(const std::string& frameName, const std::string& widgetName, TextRenderer::Color color);
+        void widgetSetBackgroundVisible(const std::string& frameName, const std::string& widgetName, bool visible);
+        void widgetSetBackgroundColor(const std::string& frameName, const std::string& widgetName, Color color);
+
+        Position widgetGetPosition(const std::string& frameName, const std::string& widgetName) const;
+        Size widgetGetSize(const std::string& frameName, const std::string& widgetName) const;
+
+    private:
+        void initializeGraphics();
+        static std::string resolveFontPath(const std::string& fontPath);
+        void updateInternal();
+        void renderInternal();
+
+        Frame& resolveFrame(const std::string& frameName);
+        const Frame& resolveFrame(const std::string& frameName) const;
+        Widget& resolveWidget(const std::string& frameName, const std::string& widgetName);
+        const Widget& resolveWidget(const std::string& frameName, const std::string& widgetName) const;
+        void registerFrame(Frame& frame);
+
+        template <typename WidgetType, typename... Args>
+        WidgetType& addWidgetImpl(const std::string& frameName, const std::string& widgetName, Args&&... args);
+
+        Window m_window;
+        TextRenderer m_textRenderer;
+        ShapeRenderer m_shapeRenderer;
+        std::string m_rootFrameName;
+        Color m_clearColor{ 0.2f, 0.3f, 0.3f, 1.0f };
+        std::map<std::string, Frame*> m_frameLookup;
+        std::map<std::string, std::map<std::string, Widget*>> m_widgetLookup;
+        StartupCallback m_startupCallback;
+        UpdateCallback m_updateCallback;
+        RenderCallback m_renderCallback;
+        ExitCallback m_exitCallback;
+        bool m_exitInvoked = false;
+    };
+
+} // namespace WidgeCraft
+
+template <typename WidgetType, typename... Args>
+WidgetType& WidgeCraft::addWidgetImpl(const std::string& frameName, const std::string& widgetName, Args&&... args) {
+    Frame& frame = resolveFrame(frameName);
+    auto& widgetMap = m_widgetLookup[frame.getName()];
+    if (widgetMap.find(widgetName) != widgetMap.end()) {
+        throw std::invalid_argument("Widget already exists: " + widgetName + " in frame " + frame.getName());
+    }
+
+    WidgetType& widget = frame.addWidget<WidgetType>(widgetName, std::forward<Args>(args)...);
+    widgetMap[widgetName] = &widget;
+    return widget;
+}
+

--- a/src/WidgeCraft.cpp
+++ b/src/WidgeCraft.cpp
@@ -1,0 +1,401 @@
+#include "WidgeCraft/WidgeCraft.hpp"
+
+#include "WidgeCraft/ShapeRenderer.hpp"
+#include "WidgeCraft/TextRenderer.hpp"
+
+// Order matters: glad before glfw
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace WidgeCraft {
+
+    namespace {
+        std::string resolveDefaultFontPath() {
+            const std::filesystem::path defaultPath = std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "fonts/Roboto-Regular.ttf";
+            return defaultPath.string();
+        }
+    }
+
+    WidgeCraft::WidgeCraft(std::string title, int width, int height, std::string fontPath, float fontPixelHeight)
+        : m_window(width, height, std::move(title))
+        , m_textRenderer(m_window.getWidth(), m_window.getHeight(), resolveFontPath(fontPath), fontPixelHeight)
+        , m_shapeRenderer() {
+        initializeGraphics();
+
+        m_rootFrameName = m_window.getRootFrame().getName();
+        registerFrame(m_window.getRootFrame());
+    }
+
+    WidgeCraft::~WidgeCraft() {
+        if (!m_exitInvoked) {
+            onExit();
+        }
+    }
+
+    void WidgeCraft::onStartup(StartupCallback callback) {
+        m_startupCallback = std::move(callback);
+        if (m_startupCallback) {
+            m_startupCallback(*this);
+        }
+    }
+
+    void WidgeCraft::onUpdate(UpdateCallback callback) {
+        m_updateCallback = std::move(callback);
+    }
+
+    void WidgeCraft::onUpdate() {
+        updateInternal();
+        renderInternal();
+
+        glfwSwapBuffers(m_window.getNativeHandle());
+        m_window.pollEvents();
+    }
+
+    void WidgeCraft::onExit() {
+        if (m_exitInvoked) {
+            return;
+        }
+
+        if (m_exitCallback) {
+            m_exitCallback(*this);
+        }
+
+        m_exitInvoked = true;
+        m_widgetLookup.clear();
+        m_frameLookup.clear();
+    }
+
+    Frame& WidgeCraft::addFrame(const std::string& frameName, const std::string& parentFrameName) {
+        if (frameName.empty()) {
+            throw std::invalid_argument("Frame name cannot be empty");
+        }
+
+        if (m_frameLookup.find(frameName) != m_frameLookup.end()) {
+            throw std::invalid_argument("Frame already exists: " + frameName);
+        }
+
+        Frame& parent = resolveFrame(parentFrameName);
+        Frame& child = parent.createChildFrame(frameName);
+        registerFrame(child);
+        return child;
+    }
+
+    bool WidgeCraft::removeFrame(const std::string& frameName) {
+        if (frameName.empty() || frameName == m_rootFrameName) {
+            return false;
+        }
+
+        auto it = m_frameLookup.find(frameName);
+        if (it == m_frameLookup.end() || it->second == nullptr) {
+            return false;
+        }
+
+        Frame* frame = it->second;
+        if (!frame->canBeDeleted()) {
+            return false;
+        }
+
+        Frame* parent = frame->getParent();
+        if (!parent) {
+            return false;
+        }
+
+        std::vector<std::string> framesToRemove;
+        std::vector<Frame*> stack;
+        stack.push_back(frame);
+        while (!stack.empty()) {
+            Frame* current = stack.back();
+            stack.pop_back();
+            if (!current) {
+                continue;
+            }
+
+            framesToRemove.emplace_back(current->getName());
+            for (const auto& child : current->getChildren()) {
+                if (child) {
+                    stack.push_back(child.get());
+                }
+            }
+        }
+
+        if (!parent->removeChildFrame(frameName)) {
+            return false;
+        }
+
+        for (const auto& name : framesToRemove) {
+            m_widgetLookup.erase(name);
+            m_frameLookup.erase(name);
+        }
+
+        return true;
+    }
+
+    void WidgeCraft::frameSetVisible(const std::string& frameName, bool visible) {
+        resolveFrame(frameName).setVisible(visible);
+    }
+
+    void WidgeCraft::frameSetBackgroundVisible(const std::string& frameName, bool visible) {
+        resolveFrame(frameName).setBackgroundVisible(visible);
+    }
+
+    void WidgeCraft::frameSetBorderVisible(const std::string& frameName, bool visible) {
+        resolveFrame(frameName).setBorderVisible(visible);
+    }
+
+    void WidgeCraft::frameSetBackgroundColor(const std::string& frameName, Color color) {
+        resolveFrame(frameName).setBackgroundColor(color);
+    }
+
+    void WidgeCraft::frameSetPosition(const std::string& frameName, float x, float y) {
+        resolveFrame(frameName).setPosition(x, y);
+    }
+
+    void WidgeCraft::frameSetSize(const std::string& frameName, float width, float height) {
+        resolveFrame(frameName).setSize(width, height);
+    }
+
+    void WidgeCraft::frameSetAnchor(const std::string& frameName, Anchor anchor) {
+        resolveFrame(frameName).setAnchor(anchor);
+    }
+
+    Position WidgeCraft::frameGetPosition(const std::string& frameName) const {
+        return resolveFrame(frameName).getPosition();
+    }
+
+    Size WidgeCraft::frameGetSize(const std::string& frameName) const {
+        return resolveFrame(frameName).getSize();
+    }
+
+    Label& WidgeCraft::addLabel(const std::string& frameName, const std::string& widgetName, std::string text) {
+        return addWidgetImpl<Label>(frameName, widgetName, std::move(text));
+    }
+
+    Button& WidgeCraft::addButton(const std::string& frameName, const std::string& widgetName, std::string text) {
+        return addWidgetImpl<Button>(frameName, widgetName, std::move(text));
+    }
+
+    bool WidgeCraft::removeWidget(const std::string& frameName, const std::string& widgetName) {
+        Frame& frame = resolveFrame(frameName);
+        auto mapIt = m_widgetLookup.find(frame.getName());
+        if (mapIt == m_widgetLookup.end()) {
+            return false;
+        }
+
+        auto widgetIt = mapIt->second.find(widgetName);
+        if (widgetIt == mapIt->second.end() || widgetIt->second == nullptr) {
+            return false;
+        }
+
+        Widget* widget = widgetIt->second;
+        auto& widgets = frame.getWidgets().getAll();
+        auto eraseIt = std::find_if(widgets.begin(), widgets.end(), [&](const std::unique_ptr<Widget>& candidate) {
+            return candidate.get() == widget;
+        });
+
+        if (eraseIt == widgets.end()) {
+            return false;
+        }
+
+        widgets.erase(eraseIt);
+        mapIt->second.erase(widgetIt);
+        return true;
+    }
+
+    void WidgeCraft::widgetSetVisible(const std::string& frameName, const std::string& widgetName, bool visible) {
+        resolveWidget(frameName, widgetName).setVisible(visible);
+    }
+
+    void WidgeCraft::widgetSetPosition(const std::string& frameName, const std::string& widgetName, float x, float y) {
+        resolveWidget(frameName, widgetName).setPosition(x, y);
+    }
+
+    void WidgeCraft::widgetSetSize(const std::string& frameName, const std::string& widgetName, float width, float height) {
+        resolveWidget(frameName, widgetName).setSize(width, height);
+    }
+
+    void WidgeCraft::widgetSetText(const std::string& frameName, const std::string& widgetName, const std::string& text) {
+        Widget& widget = resolveWidget(frameName, widgetName);
+        if (auto* label = dynamic_cast<Label*>(&widget)) {
+            label->setText(text);
+            return;
+        }
+        if (auto* button = dynamic_cast<Button*>(&widget)) {
+            button->setText(text);
+            return;
+        }
+
+        throw std::invalid_argument("widgetSetText unsupported for widget: " + widgetName);
+    }
+
+    void WidgeCraft::widgetSetTextSize(const std::string& frameName, const std::string& widgetName, float sizePixels) {
+        Widget& widget = resolveWidget(frameName, widgetName);
+        if (auto* label = dynamic_cast<Label*>(&widget)) {
+            label->setTextSize(sizePixels);
+            return;
+        }
+        if (auto* button = dynamic_cast<Button*>(&widget)) {
+            button->setTextSize(sizePixels);
+            return;
+        }
+
+        throw std::invalid_argument("widgetSetTextSize unsupported for widget: " + widgetName);
+    }
+
+    void WidgeCraft::widgetSetColor(const std::string& frameName, const std::string& widgetName, TextRenderer::Color color) {
+        Widget& widget = resolveWidget(frameName, widgetName);
+        if (auto* label = dynamic_cast<Label*>(&widget)) {
+            label->setColor(color);
+            return;
+        }
+        if (auto* button = dynamic_cast<Button*>(&widget)) {
+            button->setTextColor(color);
+            return;
+        }
+
+        throw std::invalid_argument("widgetSetColor unsupported for widget: " + widgetName);
+    }
+
+    void WidgeCraft::widgetSetTextColor(const std::string& frameName, const std::string& widgetName, TextRenderer::Color color) {
+        Widget& widget = resolveWidget(frameName, widgetName);
+        if (auto* button = dynamic_cast<Button*>(&widget)) {
+            button->setTextColor(color);
+            return;
+        }
+        if (auto* label = dynamic_cast<Label*>(&widget)) {
+            label->setColor(color);
+            return;
+        }
+
+        throw std::invalid_argument("widgetSetTextColor unsupported for widget: " + widgetName);
+    }
+
+    void WidgeCraft::widgetSetBackgroundVisible(const std::string& frameName, const std::string& widgetName, bool visible) {
+        Widget& widget = resolveWidget(frameName, widgetName);
+        if (auto* button = dynamic_cast<Button*>(&widget)) {
+            button->setBackgroundVisible(visible);
+            return;
+        }
+
+        throw std::invalid_argument("widgetSetBackgroundVisible unsupported for widget: " + widgetName);
+    }
+
+    void WidgeCraft::widgetSetBackgroundColor(const std::string& frameName, const std::string& widgetName, Color color) {
+        Widget& widget = resolveWidget(frameName, widgetName);
+        if (auto* button = dynamic_cast<Button*>(&widget)) {
+            button->setBackgroundColor(color);
+            return;
+        }
+
+        throw std::invalid_argument("widgetSetBackgroundColor unsupported for widget: " + widgetName);
+    }
+
+    Position WidgeCraft::widgetGetPosition(const std::string& frameName, const std::string& widgetName) const {
+        return resolveWidget(frameName, widgetName).getPosition();
+    }
+
+    Size WidgeCraft::widgetGetSize(const std::string& frameName, const std::string& widgetName) const {
+        return resolveWidget(frameName, widgetName).getSize();
+    }
+
+    void WidgeCraft::initializeGraphics() {
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    }
+
+    std::string WidgeCraft::resolveFontPath(const std::string& fontPath) {
+        if (!fontPath.empty()) {
+            return fontPath;
+        }
+
+        return resolveDefaultFontPath();
+    }
+
+    void WidgeCraft::updateInternal() {
+        m_textRenderer.setScreenSize(m_window.getWidth(), m_window.getHeight());
+        m_shapeRenderer.setScreenSize(static_cast<float>(m_window.getWidth()), static_cast<float>(m_window.getHeight()));
+
+        if (m_updateCallback) {
+            m_updateCallback(*this);
+        }
+    }
+
+    void WidgeCraft::renderInternal() {
+        glClearColor(m_clearColor.r, m_clearColor.g, m_clearColor.b, m_clearColor.a);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        if (m_renderCallback) {
+            m_renderCallback(*this);
+        }
+
+        m_window.getRootFrame().render(m_textRenderer, m_shapeRenderer);
+    }
+
+    Frame& WidgeCraft::resolveFrame(const std::string& frameName) {
+        if (frameName.empty()) {
+            return m_window.getRootFrame();
+        }
+
+        auto it = m_frameLookup.find(frameName);
+        if (it == m_frameLookup.end() || it->second == nullptr) {
+            throw std::invalid_argument("Unknown frame: " + frameName);
+        }
+
+        return *it->second;
+    }
+
+    const Frame& WidgeCraft::resolveFrame(const std::string& frameName) const {
+        if (frameName.empty()) {
+            return m_window.getRootFrame();
+        }
+
+        auto it = m_frameLookup.find(frameName);
+        if (it == m_frameLookup.end() || it->second == nullptr) {
+            throw std::invalid_argument("Unknown frame: " + frameName);
+        }
+
+        return *it->second;
+    }
+
+    Widget& WidgeCraft::resolveWidget(const std::string& frameName, const std::string& widgetName) {
+        Frame& frame = resolveFrame(frameName);
+        auto frameIt = m_widgetLookup.find(frame.getName());
+        if (frameIt == m_widgetLookup.end()) {
+            throw std::invalid_argument("Frame has no widget map: " + frame.getName());
+        }
+
+        auto widgetIt = frameIt->second.find(widgetName);
+        if (widgetIt == frameIt->second.end() || widgetIt->second == nullptr) {
+            throw std::invalid_argument("Unknown widget: " + widgetName + " in frame " + frame.getName());
+        }
+
+        return *widgetIt->second;
+    }
+
+    const Widget& WidgeCraft::resolveWidget(const std::string& frameName, const std::string& widgetName) const {
+        const Frame& frame = resolveFrame(frameName);
+        auto frameIt = m_widgetLookup.find(frame.getName());
+        if (frameIt == m_widgetLookup.end()) {
+            throw std::invalid_argument("Frame has no widget map: " + frame.getName());
+        }
+
+        auto widgetIt = frameIt->second.find(widgetName);
+        if (widgetIt == frameIt->second.end() || widgetIt->second == nullptr) {
+            throw std::invalid_argument("Unknown widget: " + widgetName + " in frame " + frame.getName());
+        }
+
+        return *widgetIt->second;
+    }
+
+    void WidgeCraft::registerFrame(Frame& frame) {
+        m_frameLookup[frame.getName()] = &frame;
+        m_widgetLookup.try_emplace(frame.getName());
+    }
+
+} // namespace WidgeCraft
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,66 +1,58 @@
-#include "WidgeCraft/Window.hpp"
-#include "WidgeCraft/Frame.hpp"
-#include "WidgeCraft/ShapeRenderer.hpp"
-#include "WidgeCraft/Widget.hpp"
-#include "WidgeCraft/TextRenderer.hpp"
+#include "WidgeCraft/WidgeCraft.hpp"
 
-// Order matters: glad before glfw
-#include <glad/glad.h>
-#include <GLFW/glfw3.h>
-
-#include <filesystem>
 #include <iostream>
 #include <string>
 
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;
+
     try {
-        WidgeCraft::Window window(800, 600, "WidgeCraft Engine");
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        WidgeCraft::WidgeCraft wc("WidgeCraft Engine", 800, 600);
 
-        const std::filesystem::path fontPath = std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "fonts/Roboto-Regular.ttf";
-        WidgeCraft::TextRenderer textRenderer(window.getWidth(), window.getHeight(), fontPath.string(), 64.0f);
-        WidgeCraft::ShapeRenderer shapeRenderer;
-        WidgeCraft::Frame& rootFrame = window.getRootFrame();
-        rootFrame.setBorderVisible(false);
+        const std::string rootFrameName = wc.getRootFrameName();
+        const std::string headerFrameName = "Header";
+        const std::string titleWidgetName = "TitleLabel";
+        const std::string actionWidgetName = "ActionButton";
 
-        WidgeCraft::Frame& headerFrame = rootFrame.createChildFrame("Header");
-        headerFrame.setBackgroundVisible(false);
-        headerFrame.setBorderVisible(false);
+        wc.onStartup([&](WidgeCraft::WidgeCraft& app) {
+            app.frameSetBorderVisible(rootFrameName, false);
 
-        auto& titleLabel = headerFrame.addWidget<WidgeCraft::Label>("TitleLabel", "WidgeCraft Engine");
-        auto& actionButton = headerFrame.addWidget<WidgeCraft::Button>("ActionButton", "Start Crafting");
+            app.addFrame(headerFrameName);
+            app.frameSetBackgroundVisible(headerFrameName, false);
+            app.frameSetBorderVisible(headerFrameName, false);
 
-        titleLabel.setColor({ 1.0f, 1.0f, 0.9f });
-        actionButton.setTextColor({ 0.8f, 0.9f, 1.0f });
-        actionButton.setBackgroundVisible(false);
+            app.addLabel(headerFrameName, titleWidgetName, "WidgeCraft Engine");
+            app.addButton(headerFrameName, actionWidgetName, "Start Crafting");
 
-        const float baseTextSize = textRenderer.getBasePixelHeight();
-        titleLabel.setTextSize(baseTextSize);
-        actionButton.setTextSize(baseTextSize * 0.5f);
+            app.widgetSetColor(headerFrameName, titleWidgetName, { 1.0f, 1.0f, 0.9f });
+            app.widgetSetTextColor(headerFrameName, actionWidgetName, { 0.8f, 0.9f, 1.0f });
+            app.widgetSetBackgroundVisible(headerFrameName, actionWidgetName, false);
 
-        while (!window.shouldClose()) {
-            glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
-            glClear(GL_COLOR_BUFFER_BIT);
+            const float baseTextSize = app.getTextRenderer().getBasePixelHeight();
+            app.widgetSetTextSize(headerFrameName, titleWidgetName, baseTextSize);
+            app.widgetSetTextSize(headerFrameName, actionWidgetName, baseTextSize * 0.5f);
+        });
 
-            textRenderer.setScreenSize(window.getWidth(), window.getHeight());
-            shapeRenderer.setScreenSize(static_cast<float>(window.getWidth()), static_cast<float>(window.getHeight()));
+        wc.onUpdate([&](WidgeCraft::WidgeCraft& app) {
+            auto& window = app.getWindow();
+            auto& textRenderer = app.getTextRenderer();
+
             const float margin = 40.0f;
             const float headerHeight = textRenderer.getLineHeight() * 3.0f;
-            headerFrame.setSize(static_cast<float>(window.getWidth()) - margin * 2.0f, headerHeight);
-            headerFrame.setPosition(margin, static_cast<float>(window.getHeight()) - headerHeight - margin);
+            app.frameSetSize(headerFrameName, static_cast<float>(window.getWidth()) - margin * 2.0f, headerHeight);
+            app.frameSetPosition(headerFrameName, margin, static_cast<float>(window.getHeight()) - headerHeight - margin);
 
-            const float headerTopBaseline = headerFrame.getSize().y - textRenderer.getAscent() - 10.0f;
-            titleLabel.setPosition(0.0f, headerTopBaseline);
-            actionButton.setPosition(0.0f, headerTopBaseline - textRenderer.getLineHeight());
+            const float headerTopBaseline = app.frameGetSize(headerFrameName).y - textRenderer.getAscent() - 10.0f;
+            app.widgetSetPosition(headerFrameName, titleWidgetName, { 0.0f, headerTopBaseline });
+            app.widgetSetPosition(headerFrameName, actionWidgetName, { 0.0f, headerTopBaseline - textRenderer.getLineHeight() });
+        });
 
-            rootFrame.render(textRenderer, shapeRenderer);
-
-            glfwSwapBuffers(window.getNativeHandle());
-            window.pollEvents();
+        while (!wc.shouldClose()) {
+            wc.onUpdate();
         }
+
+        wc.onExit();
     }
     catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << "\n";
@@ -70,3 +62,4 @@ int main(int argc, char* argv[]) {
 
     return 0;
 }
+


### PR DESCRIPTION
## Summary
- extend the `WidgeCraft` wrapper with startup/update/exit hooks, frame/widget registries, and helper methods for manipulating frames and widgets by name
- manage frame/widget lifecycles through ordered maps so lookups validate names and remain consistent when removing elements
- simplify `main.cpp` to register startup/update callbacks, create UI via the new API, and drive the loop explicitly with `wc.onUpdate()`

## Testing
- cmake -S . -B build *(fails: RandR headers not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cae2267c83218ddaad90f0ada44d