### PR TITLE
Build out the WidgeCraft engine foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: windows-latest
+    # Pin the runner because windows-latest now carries VS2026, while the
+    # supported WidgeCraft preset intentionally generates a VS2022 solution.
+    runs-on: windows-2022
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,23 @@
-name: CI (Win32 Release)
+name: CI (VS2022 Win32 Release)
 
 on:
   push:
   pull_request:
 
 jobs:
-  build:
+  build-and-test:
     runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
+    timeout-minutes: 20
 
-      - name: Configure (VS2022 Win32)
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Configure Visual Studio 2022 Win32
         run: cmake --preset vs2022-win32-release
 
-      - name: Build (Release)
+      - name: Build Release
         run: cmake --build --preset build-release --parallel
 
-      - name: Run app
-        run: .\build\win32-release\Release\widgecraft.exe
+      - name: Run non-graphical tests
+        run: ctest --preset test-release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required(VERSION 3.25)
-project(WidgeCraft LANGUAGES CXX)
+project(WidgeCraft VERSION 0.2.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(WIDGECRAFT_BUILD_DEMO "Build the interactive WidgeCraft showcase" ON)
+option(WIDGECRAFT_BUILD_TESTS "Build WidgeCraft unit tests" ON)
 
 include(FetchContent)
 
@@ -14,47 +18,91 @@ set(GLFW_INSTALL        OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_WAYLAND  OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
-  glfw
-  GIT_REPOSITORY https://github.com/glfw/glfw.git
-  GIT_TAG 3.4
+    glfw
+    GIT_REPOSITORY https://github.com/glfw/glfw.git
+    GIT_TAG 3.4
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(glfw)
 
 # ---------------- GLAD ----------------
 FetchContent_Declare(
-  glad
-  GIT_REPOSITORY https://github.com/Dav1dde/glad.git
-  GIT_TAG v0.1.36
+    glad
+    GIT_REPOSITORY https://github.com/Dav1dde/glad.git
+    GIT_TAG v0.1.36
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(glad)
 
-# ---------------- Executable ----------------
-add_executable(widgecraft
-    src/main.cpp
+function(widgecraft_enable_warnings target)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4 /permissive- /Zc:__cplusplus)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+endfunction()
+
+# ---------------- Engine library ----------------
+add_library(widgecraft_engine STATIC
     src/Window.cpp
+    src/Input.cpp
     src/TextRenderer.cpp
     src/ShapeRenderer.cpp
     src/Frame.cpp
     src/Widget.cpp
+    src/Raycast.cpp
     src/WidgeCraft.cpp
 )
 
-target_include_directories(widgecraft
-    PRIVATE
+add_library(WidgeCraft::Engine ALIAS widgecraft_engine)
+
+set_target_properties(widgecraft_engine PROPERTIES
+    OUTPUT_NAME WidgeCraft
+    FOLDER "WidgeCraft"
+)
+
+target_include_directories(widgecraft_engine
+    PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
+    PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party
 )
 
-target_compile_definitions(widgecraft
-    PRIVATE
+target_compile_definitions(widgecraft_engine
+    PUBLIC
         WIDGECRAFT_ASSET_DIR="${CMAKE_CURRENT_SOURCE_DIR}/assets"
 )
 
-target_link_libraries(widgecraft PRIVATE glfw glad)
+target_link_libraries(widgecraft_engine PUBLIC glfw glad)
+widgecraft_enable_warnings(widgecraft_engine)
 
-# ---------------- Warnings ----------------
-if(MSVC)
-    target_compile_options(widgecraft PRIVATE /W4 /permissive-)
-else()
-    target_compile_options(widgecraft PRIVATE -Wall -Wextra -Wpedantic)
+# ---------------- Interactive showcase ----------------
+if(WIDGECRAFT_BUILD_DEMO)
+    add_executable(widgecraft src/main.cpp)
+    set_target_properties(widgecraft PROPERTIES FOLDER "Examples")
+    target_link_libraries(widgecraft PRIVATE WidgeCraft::Engine)
+    widgecraft_enable_warnings(widgecraft)
+
+    add_custom_command(TARGET widgecraft POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_SOURCE_DIR}/assets
+            $<TARGET_FILE_DIR:widgecraft>/assets
+        COMMENT "Copying WidgeCraft assets"
+    )
+endif()
+
+# ---------------- Tests ----------------
+if(WIDGECRAFT_BUILD_TESTS)
+    include(CTest)
+    enable_testing()
+
+    add_executable(widgecraft_raycast_tests
+        tests/RaycastTests.cpp
+        src/Raycast.cpp
+    )
+    set_target_properties(widgecraft_raycast_tests PROPERTIES FOLDER "Tests")
+    target_include_directories(widgecraft_raycast_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    widgecraft_enable_warnings(widgecraft_raycast_tests)
+
+    add_test(NAME WidgeCraft.Raycast COMMAND widgecraft_raycast_tests)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,17 +5,21 @@
     {
       "name": "vs2022-win32-release",
       "displayName": "VS2022 Win32 Release",
+      "description": "Generates the supported 32-bit Visual Studio 2022 solution.",
       "generator": "Visual Studio 17 2022",
       "architecture": { "value": "Win32", "strategy": "set" },
       "binaryDir": "${sourceDir}/build/win32-release",
       "cacheVariables": {
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install"
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install",
+        "WIDGECRAFT_BUILD_DEMO": "ON",
+        "WIDGECRAFT_BUILD_TESTS": "ON"
       }
     }
   ],
   "buildPresets": [
     {
       "name": "build-release",
+      "displayName": "Build Win32 Release",
       "configurePreset": "vs2022-win32-release",
       "configuration": "Release"
     }
@@ -23,6 +27,7 @@
   "testPresets": [
     {
       "name": "test-release",
+      "displayName": "Test Win32 Release",
       "configurePreset": "vs2022-win32-release",
       "configuration": "Release",
       "output": { "outputOnFailure": true }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ panel.setAnchor(WidgeCraft::Anchor::TopRight);
 panel.setPosition(20.0f, 20.0f);
 panel.setSize(300.0f, 220.0f);
 
-	auto& button = panel.addWidget<WidgeCraft::Button>("Apply", "Apply");
+auto& button = panel.addWidget<WidgeCraft::Button>("Apply", "Apply");
 button.setAnchor(WidgeCraft::Anchor::BottomRight);
 button.setPosition(16.0f, 16.0f);
 button.setSize(100.0f, 38.0f);
@@ -157,7 +157,7 @@ assets/                 Fonts and future engine assets
 include/WidgeCraft/     Public engine headers
 src/                    Engine implementation and showcase
 third_party/            Header-only third-party source
- tests/                  Non-graphical unit tests
+tests/                  Non-graphical unit tests
 .github/workflows/      Win32 CI build and tests
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,166 @@
+# WidgeCraft
+
+WidgeCraft is a small retained-mode graphics and UI engine for Windows, C++17 and OpenGL 3.3 Core. The project is deliberately focused: useful pixel-space primitives, scalable SDF text, a built-in widget tree, and clean ray queries without depending on an immediate-mode UI library.
+
+The current supported development target is **Visual Studio 2022, Win32, Release**.
+
+## Current engine foundation
+
+### Batched 2D primitives
+
+`ShapeRenderer` batches coloured triangles and builds the common primitives on top:
+
+- Points
+- Thick lines
+- Filled triangles
+- Filled and outlined rectangles
+- Filled and outlined circles with adaptive tessellation
+
+```cpp
+auto& shapes = app.getShapeRenderer();
+shapes.drawLine(20.0f, 20.0f, 220.0f, 80.0f, 4.0f, WidgeCraft::Colors::Cyan);
+shapes.drawFilledCircle(320.0f, 180.0f, 48.0f, WidgeCraft::Colors::Orange);
+shapes.drawRectOutline(400.0f, 100.0f, 160.0f, 90.0f, 3.0f, WidgeCraft::Colors::Green);
+```
+
+### SDF text
+
+`TextRenderer` creates a signed-distance-field atlas from a TrueType font and batches glyphs into one draw per layer. It includes:
+
+- Smooth scaling from small labels to large headings
+- Mipmapped atlas sampling
+- Derivative-based edge smoothing
+- Kerning
+- UTF-8 decoding for the bundled Western/common-symbol atlas
+- Text bounds and width measurement
+- Per-glyph colour and alpha
+
+```cpp
+auto& text = app.getTextRenderer();
+text.renderText("Small and crisp", 30.0f, 80.0f, 12.0f, WidgeCraft::Colors::White);
+text.renderText("Large SDF", 30.0f, 180.0f, 72.0f, { 0.3f, 0.8f, 1.0f, 1.0f });
+```
+
+### Retained UI
+
+Frames own child frames and widgets. Frames and widgets support anchors and offsets in a bottom-left pixel coordinate system. Frame contents are clipped using OpenGL scissor rectangles.
+
+Included widgets:
+
+- `Label`
+- `Button` with hover, press, release and click callback states
+- `Checkbox` with a change callback
+
+```cpp
+auto& panel = app.getRootFrame().createChildFrame("Inspector");
+panel.setAnchor(WidgeCraft::Anchor::TopRight);
+panel.setPosition(20.0f, 20.0f);
+panel.setSize(300.0f, 220.0f);
+
+	auto& button = panel.addWidget<WidgeCraft::Button>("Apply", "Apply");
+button.setAnchor(WidgeCraft::Anchor::BottomRight);
+button.setPosition(16.0f, 16.0f);
+button.setSize(100.0f, 38.0f);
+button.setOnClick([] {
+    // Apply changes.
+});
+```
+
+Names are unique within each parent frame. Frames and widgets can be found or removed by name.
+
+### Input
+
+`Input` records frame transitions rather than exposing only raw GLFW state:
+
+```cpp
+const auto& input = app.getInput();
+if (input.mousePressed(WidgeCraft::MouseButton::Left)) {
+    const WidgeCraft::Vec2 position = input.mousePosition();
+}
+```
+
+Available state includes key and mouse `down`, `pressed` and `released`, pointer position/delta, and wheel delta.
+
+### Raycasting and ray picking
+
+The ray module is independent from OpenGL and can be unit tested without opening a window. It currently includes:
+
+- Ray versus sphere
+- Ray versus axis-aligned bounding box
+- Ray versus plane
+- Ray versus triangle, with optional back-face culling
+- Screen point to world ray using view and projection matrices
+- Matrix inversion and hit point/normal/distance data
+
+```cpp
+WidgeCraft::Ray ray{ cameraPosition, rayDirection };
+WidgeCraft::RayHit hit{};
+
+if (WidgeCraft::raycast(ray, objectBounds, hit)) {
+    // hit.distance, hit.point and hit.normal are available here.
+}
+```
+
+## Generate the Visual Studio solution
+
+From a Visual Studio Developer Command Prompt:
+
+```bat
+cmake --preset vs2022-win32-release
+```
+
+Or double-click:
+
+```text
+generate_vs2022_win32.bat
+```
+
+Open:
+
+```text
+build\win32-release\WidgeCraft.sln
+```
+
+The main targets are:
+
+- `widgecraft_engine` / `WidgeCraft::Engine` — reusable static engine library
+- `widgecraft` — interactive showcase
+- `widgecraft_raycast_tests` — non-graphical ray tests
+
+## Build and test
+
+```bat
+cmake --build --preset build-release --parallel
+ctest --preset test-release
+```
+
+The showcase executable is generated at:
+
+```text
+build\win32-release\Release\widgecraft.exe
+```
+
+Assets are copied beside the executable after a successful build.
+
+## Coordinate conventions
+
+- 2D screen and UI coordinates use a **bottom-left origin**.
+- Positive X points right; positive Y points up.
+- Text X/Y is its baseline origin.
+- GLFW cursor coordinates are converted into framebuffer pixels, including high-DPI scaling.
+- Matrices use OpenGL-compatible column-major storage.
+
+## Project structure
+
+```text
+assets/                 Fonts and future engine assets
+include/WidgeCraft/     Public engine headers
+src/                    Engine implementation and showcase
+third_party/            Header-only third-party source
+ tests/                  Non-graphical unit tests
+.github/workflows/      Win32 CI build and tests
+```
+
+## Near-term direction
+
+This branch establishes the engine foundation rather than trying to hide unfinished areas. Logical next additions are a dedicated 3D model renderer and camera, texture/image primitives, keyboard focus and navigation, richer text ranges, movable/closable windows, and a broad-phase structure such as a BVH for large ray-picking scenes.

--- a/generate_vs2022_win32.bat
+++ b/generate_vs2022_win32.bat
@@ -1,0 +1,27 @@
+@echo off
+setlocal
+
+where cmake >nul 2>nul
+if errorlevel 1 (
+    echo CMake was not found. Install CMake or run this from a Visual Studio Developer Command Prompt.
+    pause
+    exit /b 1
+)
+
+pushd "%~dp0"
+cmake --preset vs2022-win32-release
+if errorlevel 1 (
+    echo.
+    echo WidgeCraft solution generation failed.
+    popd
+    pause
+    exit /b 1
+)
+
+set "SOLUTION=%CD%\build\win32-release\WidgeCraft.sln"
+echo.
+echo Generated: %SOLUTION%
+
+if exist "%SOLUTION%" start "" "%SOLUTION%"
+popd
+endlocal

--- a/include/WidgeCraft/Frame.hpp
+++ b/include/WidgeCraft/Frame.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "WidgeCraft/Input.hpp"
 #include "WidgeCraft/TextRenderer.hpp"
 #include "WidgeCraft/Types.hpp"
 #include "WidgeCraft/Widget.hpp"
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -21,12 +23,11 @@ namespace WidgeCraft {
                 std::string text;
                 Position position;
                 float sizePixels = 0.0f;
-                TextRenderer::Color color{ 1.0f, 1.0f, 1.0f };
+                Color color{ Colors::White };
             };
 
-            void addText(std::string text, float x, float y, float sizePixels, TextRenderer::Color color);
+            void addText(std::string text, float x, float y, float sizePixels, Color color = Colors::White);
             void clear();
-
             const std::vector<Command>& getCommands() const { return m_commands; }
 
         private:
@@ -48,12 +49,17 @@ namespace WidgeCraft {
 
         void setBackgroundVisible(bool visible) { m_showBackground = visible; }
         bool isBackgroundVisible() const { return m_showBackground; }
-
         void setBorderVisible(bool visible) { m_showBorder = visible; }
         bool isBorderVisible() const { return m_showBorder; }
+        void setClipContents(bool clipContents) { m_clipContents = clipContents; }
+        bool clipsContents() const { return m_clipContents; }
 
         void setBackgroundColor(Color color) { m_backgroundColor = color; }
         Color getBackgroundColor() const { return m_backgroundColor; }
+        void setBorderColor(Color color) { m_borderColor = color; }
+        Color getBorderColor() const { return m_borderColor; }
+        void setBorderThickness(float thickness) { m_borderThickness = thickness; }
+        float getBorderThickness() const { return m_borderThickness; }
 
         void setPosition(float x, float y);
         void setPosition(const Position& position) { setPosition(position.x, position.y); }
@@ -67,12 +73,19 @@ namespace WidgeCraft {
         Anchor getAnchor() const { return m_anchor; }
 
         Position getAbsolutePosition() const;
+        Rect getAbsoluteRect() const;
 
         Frame& createChildFrame(const std::string& name);
+        Frame* findChildFrame(const std::string& name);
+        const Frame* findChildFrame(const std::string& name) const;
         bool removeChildFrame(const std::string& name);
 
         template <typename T, typename... Args>
         T& addWidget(Args&&... args);
+
+        Widget* findWidget(const std::string& name) { return m_widgets.find(name); }
+        const Widget* findWidget(const std::string& name) const { return m_widgets.find(name); }
+        bool removeWidget(const std::string& name) { return m_widgets.remove(name); }
 
         TextBatch& getTextBatch() { return m_textBatch; }
         const TextBatch& getTextBatch() const { return m_textBatch; }
@@ -85,23 +98,30 @@ namespace WidgeCraft {
         void setDeletable(bool deletable) { m_deletable = deletable; }
         bool canBeDeleted() const { return m_deletable; }
 
-        void render(TextRenderer& textRenderer, ShapeRenderer& shapeRenderer);
+        void render(TextRenderer& textRenderer, ShapeRenderer& shapeRenderer, const Input& input);
 
     private:
+        void renderInternal(
+            TextRenderer& textRenderer,
+            ShapeRenderer& shapeRenderer,
+            const Input& input,
+            const Rect& parentClip,
+            bool isRoot);
         void clearTextBatchesRecursive();
-        Frame* getRoot();
-        const Frame* getRoot() const;
 
         std::string m_name;
         Frame* m_parent = nullptr;
         bool m_visible = true;
         bool m_showBackground = true;
         bool m_showBorder = false;
+        bool m_clipContents = true;
         bool m_deletable = true;
         Color m_backgroundColor{ Colors::Grey };
-        Position m_position{ 10.0f, 10.0f };
+        Color m_borderColor{ Colors::Black };
+        float m_borderThickness = 1.0f;
+        Position m_position{ 0.0f, 0.0f };
         Size m_size{};
-        Anchor m_anchor = Anchor::Center;
+        Anchor m_anchor = Anchor::BottomLeft;
         TextBatch m_textBatch;
         Widgets m_widgets;
         std::vector<std::unique_ptr<Frame>> m_children;

--- a/include/WidgeCraft/Input.hpp
+++ b/include/WidgeCraft/Input.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "WidgeCraft/Types.hpp"
+
+#include <array>
+
+namespace WidgeCraft {
+
+    enum class MouseButton : int {
+        Left = 0,
+        Right = 1,
+        Middle = 2
+    };
+
+    class Input {
+    public:
+        static constexpr int MaxKeys = 512;
+        static constexpr int MaxMouseButtons = 8;
+
+        void beginFrame();
+
+        bool keyDown(int key) const;
+        bool keyPressed(int key) const;
+        bool keyReleased(int key) const;
+
+        bool mouseDown(MouseButton button) const;
+        bool mousePressed(MouseButton button) const;
+        bool mouseReleased(MouseButton button) const;
+
+        Vec2 mousePosition() const { return m_mousePosition; }
+        Vec2 mouseDelta() const { return m_mouseDelta; }
+        Vec2 scrollDelta() const { return m_scrollDelta; }
+
+    private:
+        friend class Window;
+
+        void setKey(int key, bool down);
+        void setMouseButton(int button, bool down);
+        void setMousePosition(float x, float y);
+        void addScroll(float x, float y);
+
+        std::array<bool, MaxKeys> m_keys{};
+        std::array<bool, MaxKeys> m_previousKeys{};
+        std::array<bool, MaxMouseButtons> m_mouseButtons{};
+        std::array<bool, MaxMouseButtons> m_previousMouseButtons{};
+        Vec2 m_mousePosition{};
+        Vec2 m_previousMousePosition{};
+        Vec2 m_mouseDelta{};
+        Vec2 m_scrollDelta{};
+    };
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/Raycast.hpp
+++ b/include/WidgeCraft/Raycast.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "WidgeCraft/Types.hpp"
+
+namespace WidgeCraft {
+
+    struct Ray {
+        Vec3 origin{};
+        Vec3 direction{ 0.0f, 0.0f, -1.0f };
+
+        Vec3 pointAt(float distance) const {
+            return origin + direction * distance;
+        }
+    };
+
+    struct RayHit {
+        float distance = 0.0f;
+        Vec3 point{};
+        Vec3 normal{};
+        float u = 0.0f;
+        float v = 0.0f;
+    };
+
+    struct Sphere {
+        Vec3 center{};
+        float radius = 1.0f;
+    };
+
+    struct AABB {
+        Vec3 minimum{ -0.5f, -0.5f, -0.5f };
+        Vec3 maximum{ 0.5f, 0.5f, 0.5f };
+    };
+
+    struct Plane {
+        Vec3 normal{ 0.0f, 1.0f, 0.0f };
+        float distance = 0.0f; // dot(normal, point) + distance = 0
+    };
+
+    struct Triangle {
+        Vec3 a{};
+        Vec3 b{};
+        Vec3 c{};
+    };
+
+    bool invert(const Mat4& matrix, Mat4& inverseMatrix);
+
+    bool raycast(const Ray& ray, const Sphere& sphere, RayHit& hit);
+    bool raycast(const Ray& ray, const AABB& box, RayHit& hit);
+    bool raycast(const Ray& ray, const Plane& plane, RayHit& hit);
+    bool raycast(const Ray& ray, const Triangle& triangle, RayHit& hit, bool cullBackFaces = false);
+
+    // screenX/screenY use WidgeCraft's bottom-left pixel coordinate system.
+    Ray screenPointToRay(
+        float screenX,
+        float screenY,
+        float viewportWidth,
+        float viewportHeight,
+        const Mat4& view,
+        const Mat4& projection);
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/ShapeRenderer.hpp
+++ b/include/WidgeCraft/ShapeRenderer.hpp
@@ -2,7 +2,8 @@
 
 #include "WidgeCraft/Types.hpp"
 
-#include <glad/glad.h>
+#include <cstddef>
+#include <vector>
 
 namespace WidgeCraft {
 
@@ -17,22 +18,42 @@ namespace WidgeCraft {
         ShapeRenderer& operator=(ShapeRenderer&& other) noexcept;
 
         void setScreenSize(float width, float height);
+        void beginFrame();
+        void flush();
 
-        void drawFilledRect(float x, float y, float width, float height, const Color& color) const;
-        void drawRectOutline(float x, float y, float width, float height, float thickness, const Color& color) const;
+        void reserve(std::size_t triangleCount);
+
+        void drawPoint(float x, float y, float size, const Color& color);
+        void drawLine(float x1, float y1, float x2, float y2, float thickness, const Color& color);
+        void drawTriangle(const Vec2& a, const Vec2& b, const Vec2& c, const Color& color);
+        void drawFilledRect(float x, float y, float width, float height, const Color& color);
+        void drawRectOutline(float x, float y, float width, float height, float thickness, const Color& color);
+        void drawFilledCircle(float centerX, float centerY, float radius, const Color& color, int segments = 0);
+        void drawCircleOutline(float centerX, float centerY, float radius, float thickness, const Color& color, int segments = 0);
+
+        std::size_t getQueuedTriangleCount() const { return m_vertices.size() / 3; }
 
     private:
+        struct Vertex {
+            float x = 0.0f;
+            float y = 0.0f;
+            float r = 1.0f;
+            float g = 1.0f;
+            float b = 1.0f;
+            float a = 1.0f;
+        };
+
+        void addVertex(const Vec2& position, const Color& color);
         void moveFrom(ShapeRenderer&& other) noexcept;
         void cleanup();
 
-        GLuint m_vao = 0;
-        GLuint m_vbo = 0;
-        GLuint m_shader = 0;
-        GLint m_uniformScreenSize = -1;
-        GLint m_uniformColor = -1;
+        unsigned int m_vao = 0;
+        unsigned int m_vbo = 0;
+        unsigned int m_shader = 0;
+        int m_uniformScreenSize = -1;
         float m_screenWidth = 0.0f;
         float m_screenHeight = 0.0f;
+        std::vector<Vertex> m_vertices;
     };
 
 } // namespace WidgeCraft
-

--- a/include/WidgeCraft/TextRenderer.hpp
+++ b/include/WidgeCraft/TextRenderer.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <array>
+#include "WidgeCraft/Types.hpp"
+
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -13,20 +15,19 @@ namespace WidgeCraft {
 
     class TextRenderer {
     public:
-        struct Color {
-            float r = 1.0f;
-            float g = 1.0f;
-            float b = 1.0f;
-        };
+        using Color = WidgeCraft::Color;
 
         struct TextBounds {
             float minX = 0.0f;
             float minY = 0.0f;
             float maxX = 0.0f;
             float maxY = 0.0f;
+
+            float width() const { return maxX - minX; }
+            float height() const { return maxY - minY; }
         };
 
-        TextRenderer(int screenWidth, int screenHeight, const std::string& fontPath, float fontPixelHeight = 48.0f);
+        TextRenderer(int screenWidth, int screenHeight, const std::string& fontPath, float fontPixelHeight = 64.0f);
         ~TextRenderer();
 
         TextRenderer(const TextRenderer&) = delete;
@@ -35,41 +36,61 @@ namespace WidgeCraft {
         TextRenderer& operator=(TextRenderer&& other) noexcept;
 
         void setScreenSize(int width, int height);
-        void renderText(const std::string& text, float x, float y, float sizePixels = 0.0f, Color color = Color{1.0f, 1.0f, 1.0f});
+        void beginFrame();
+        void flush();
+
+        // x/y is the baseline origin in WidgeCraft's bottom-left coordinate system.
+        void renderText(const std::string& text, float x, float y, float sizePixels = 0.0f, Color color = Colors::White);
+        void renderTextCentered(const std::string& text, float centerX, float centerY, float sizePixels = 0.0f, Color color = Colors::White);
 
         std::optional<TextBounds> measureTextBounds(const std::string& text, float sizePixels = 0.0f) const;
+        float measureTextWidth(const std::string& text, float sizePixels = 0.0f) const;
 
         float getLineHeight() const { return m_lineHeight; }
         float getAscent() const { return m_ascent; }
+        float getDescent() const { return m_descent; }
         float getBasePixelHeight() const { return m_basePixelHeight; }
+        std::size_t getQueuedGlyphCount() const { return m_vertices.size() / 6; }
 
     private:
         struct Glyph {
-            float advance;
-            float xOffset;
-            float yOffset;
-            float width;
-            float height;
-            float u0;
-            float v0;
-            float u1;
-            float v1;
-            int glyphIndex;
+            float advance = 0.0f;
+            float xOffset = 0.0f;
+            float yOffset = 0.0f;
+            float width = 0.0f;
+            float height = 0.0f;
+            float u0 = 0.0f;
+            float v0 = 0.0f;
+            float u1 = 0.0f;
+            float v1 = 0.0f;
+            int glyphIndex = 0;
+        };
+
+        struct Vertex {
+            float x = 0.0f;
+            float y = 0.0f;
+            float u = 0.0f;
+            float v = 0.0f;
+            float r = 1.0f;
+            float g = 1.0f;
+            float b = 1.0f;
+            float a = 1.0f;
         };
 
         void cleanup();
         void moveFrom(TextRenderer&& other) noexcept;
-
         void createShader();
         void createBuffers();
         void uploadAtlasTexture();
         void updateProjection();
-
         bool loadFont(const std::string& fontPath);
         void buildAtlas(float pixelHeight);
+        const Glyph* findGlyph(char32_t codepoint) const;
 
-        std::unordered_map<char, Glyph> m_glyphs;
+        std::unordered_map<char32_t, Glyph> m_glyphs;
         std::vector<unsigned char> m_atlasData;
+        std::vector<unsigned char> m_fontBuffer;
+        std::vector<Vertex> m_vertices;
         int m_atlasWidth = 0;
         int m_atlasHeight = 0;
 
@@ -79,28 +100,22 @@ namespace WidgeCraft {
         unsigned int m_shader = 0;
 
         std::unique_ptr<stbtt_fontinfo> m_fontInfo;
-        std::vector<unsigned char> m_fontBuffer;
+        const Glyph* m_fallbackGlyph = nullptr;
 
         float m_scale = 1.0f;
         float m_ascent = 0.0f;
         float m_descent = 0.0f;
         float m_lineHeight = 0.0f;
         float m_basePixelHeight = 0.0f;
+        float m_edgeValue = 0.0f;
+        float m_softness = 1.0f;
 
         int m_screenWidth = 0;
         int m_screenHeight = 0;
-
-        float m_edgeValue = 0.0f;
-        float m_smoothing = 0.0f;
-
         int m_uniformProjection = -1;
-        int m_uniformTextColor = -1;
         int m_uniformEdgeValue = -1;
-        int m_uniformSmoothing = -1;
-
-        std::array<float, 16> m_projection{};
-
-        const Glyph* m_fallbackGlyph = nullptr;
+        int m_uniformSoftness = -1;
+        Mat4 m_projection = Mat4::identity();
     };
 
 } // namespace WidgeCraft

--- a/include/WidgeCraft/Types.hpp
+++ b/include/WidgeCraft/Types.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+
 namespace WidgeCraft {
 
     struct Color {
@@ -9,10 +13,142 @@ namespace WidgeCraft {
         float a = 1.0f;
     };
 
+    using Colour = Color;
+
     struct Vec2 {
         float x = 0.0f;
         float y = 0.0f;
+
+        constexpr Vec2 operator+(const Vec2& rhs) const { return { x + rhs.x, y + rhs.y }; }
+        constexpr Vec2 operator-(const Vec2& rhs) const { return { x - rhs.x, y - rhs.y }; }
+        constexpr Vec2 operator*(float scalar) const { return { x * scalar, y * scalar }; }
+        constexpr Vec2 operator/(float scalar) const { return { x / scalar, y / scalar }; }
+        Vec2& operator+=(const Vec2& rhs) { x += rhs.x; y += rhs.y; return *this; }
+        Vec2& operator-=(const Vec2& rhs) { x -= rhs.x; y -= rhs.y; return *this; }
     };
+
+    inline float dot(const Vec2& lhs, const Vec2& rhs) {
+        return lhs.x * rhs.x + lhs.y * rhs.y;
+    }
+
+    inline float lengthSquared(const Vec2& value) {
+        return dot(value, value);
+    }
+
+    inline float length(const Vec2& value) {
+        return std::sqrt(lengthSquared(value));
+    }
+
+    inline Vec2 normalized(const Vec2& value) {
+        const float magnitude = length(value);
+        return magnitude > 0.0f ? value / magnitude : Vec2{};
+    }
+
+    struct Vec3 {
+        float x = 0.0f;
+        float y = 0.0f;
+        float z = 0.0f;
+
+        constexpr Vec3 operator+(const Vec3& rhs) const { return { x + rhs.x, y + rhs.y, z + rhs.z }; }
+        constexpr Vec3 operator-(const Vec3& rhs) const { return { x - rhs.x, y - rhs.y, z - rhs.z }; }
+        constexpr Vec3 operator-() const { return { -x, -y, -z }; }
+        constexpr Vec3 operator*(float scalar) const { return { x * scalar, y * scalar, z * scalar }; }
+        constexpr Vec3 operator/(float scalar) const { return { x / scalar, y / scalar, z / scalar }; }
+        Vec3& operator+=(const Vec3& rhs) { x += rhs.x; y += rhs.y; z += rhs.z; return *this; }
+        Vec3& operator-=(const Vec3& rhs) { x -= rhs.x; y -= rhs.y; z -= rhs.z; return *this; }
+    };
+
+    inline float dot(const Vec3& lhs, const Vec3& rhs) {
+        return lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z;
+    }
+
+    inline Vec3 cross(const Vec3& lhs, const Vec3& rhs) {
+        return {
+            lhs.y * rhs.z - lhs.z * rhs.y,
+            lhs.z * rhs.x - lhs.x * rhs.z,
+            lhs.x * rhs.y - lhs.y * rhs.x
+        };
+    }
+
+    inline float lengthSquared(const Vec3& value) {
+        return dot(value, value);
+    }
+
+    inline float length(const Vec3& value) {
+        return std::sqrt(lengthSquared(value));
+    }
+
+    inline Vec3 normalized(const Vec3& value) {
+        const float magnitude = length(value);
+        return magnitude > 0.0f ? value / magnitude : Vec3{};
+    }
+
+    struct Vec4 {
+        float x = 0.0f;
+        float y = 0.0f;
+        float z = 0.0f;
+        float w = 0.0f;
+    };
+
+    struct Rect {
+        float x = 0.0f;
+        float y = 0.0f;
+        float width = 0.0f;
+        float height = 0.0f;
+
+        constexpr float right() const { return x + width; }
+        constexpr float top() const { return y + height; }
+
+        constexpr bool contains(const Vec2& point) const {
+            return point.x >= x && point.x <= right() && point.y >= y && point.y <= top();
+        }
+    };
+
+    inline Rect intersect(const Rect& lhs, const Rect& rhs) {
+        const float left = std::max(lhs.x, rhs.x);
+        const float bottom = std::max(lhs.y, rhs.y);
+        const float right = std::min(lhs.right(), rhs.right());
+        const float top = std::min(lhs.top(), rhs.top());
+        return { left, bottom, std::max(0.0f, right - left), std::max(0.0f, top - bottom) };
+    }
+
+    struct Mat4 {
+        // OpenGL-compatible column-major storage.
+        std::array<float, 16> values{};
+
+        static constexpr Mat4 identity() {
+            return { {
+                1.0f, 0.0f, 0.0f, 0.0f,
+                0.0f, 1.0f, 0.0f, 0.0f,
+                0.0f, 0.0f, 1.0f, 0.0f,
+                0.0f, 0.0f, 0.0f, 1.0f
+            } };
+        }
+
+        constexpr float& operator()(int row, int column) { return values[static_cast<size_t>(column * 4 + row)]; }
+        constexpr float operator()(int row, int column) const { return values[static_cast<size_t>(column * 4 + row)]; }
+    };
+
+    inline Mat4 operator*(const Mat4& lhs, const Mat4& rhs) {
+        Mat4 result{};
+        for (int row = 0; row < 4; ++row) {
+            for (int column = 0; column < 4; ++column) {
+                for (int index = 0; index < 4; ++index) {
+                    result(row, column) += lhs(row, index) * rhs(index, column);
+                }
+            }
+        }
+        return result;
+    }
+
+    inline Vec4 operator*(const Mat4& matrix, const Vec4& vector) {
+        return {
+            matrix(0, 0) * vector.x + matrix(0, 1) * vector.y + matrix(0, 2) * vector.z + matrix(0, 3) * vector.w,
+            matrix(1, 0) * vector.x + matrix(1, 1) * vector.y + matrix(1, 2) * vector.z + matrix(1, 3) * vector.w,
+            matrix(2, 0) * vector.x + matrix(2, 1) * vector.y + matrix(2, 2) * vector.z + matrix(2, 3) * vector.w,
+            matrix(3, 0) * vector.x + matrix(3, 1) * vector.y + matrix(3, 2) * vector.z + matrix(3, 3) * vector.w
+        };
+    }
 
     using Position = Vec2;
     using Size = Vec2;
@@ -33,8 +169,6 @@ namespace WidgeCraft {
         BottomCenter,
         BottomRight
     };
-
-    using Colour = Color;
 
     namespace Colors {
         inline constexpr Color Transparent{ 0.0f, 0.0f, 0.0f, 0.0f };
@@ -58,4 +192,3 @@ namespace WidgeCraft {
     } // namespace Colours
 
 } // namespace WidgeCraft
-

--- a/include/WidgeCraft/WidgeCraft.hpp
+++ b/include/WidgeCraft/WidgeCraft.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "WidgeCraft/Input.hpp"
+#include "WidgeCraft/Raycast.hpp"
 #include "WidgeCraft/ShapeRenderer.hpp"
 #include "WidgeCraft/TextRenderer.hpp"
 #include "WidgeCraft/Types.hpp"
@@ -20,11 +22,11 @@ namespace WidgeCraft {
 
         WidgeCraft(const WidgeCraft&) = delete;
         WidgeCraft& operator=(const WidgeCraft&) = delete;
-        WidgeCraft(WidgeCraft&&) noexcept = default;
-        WidgeCraft& operator=(WidgeCraft&&) noexcept = default;
+        WidgeCraft(WidgeCraft&&) = delete;
+        WidgeCraft& operator=(WidgeCraft&&) = delete;
 
-        void Run();
-
+        void Run(int targetFramesPerSecond = 60);
+        void Stop();
         void Update();
         void Render();
 
@@ -34,8 +36,14 @@ namespace WidgeCraft {
         void setClearColor(Color color) { m_clearColor = color; }
         Color getClearColor() const { return m_clearColor; }
 
+        float getDeltaTime() const { return m_deltaTime; }
+        double getElapsedTime() const { return m_elapsedTime; }
+        int getTargetFrameRate() const { return m_targetFrameRate; }
+
         Window& getWindow() { return m_window; }
         const Window& getWindow() const { return m_window; }
+        Input& getInput() { return m_window.getInput(); }
+        const Input& getInput() const { return m_window.getInput(); }
 
         Frame& getRootFrame() { return m_window.getRootFrame(); }
         const Frame& getRootFrame() const { return m_window.getRootFrame(); }
@@ -53,10 +61,12 @@ namespace WidgeCraft {
         Window m_window;
         TextRenderer m_textRenderer;
         ShapeRenderer m_shapeRenderer;
-        Color m_clearColor{ 0.2f, 0.3f, 0.3f, 1.0f };
+        Color m_clearColor{ 0.055f, 0.070f, 0.095f, 1.0f };
         UpdateCallback m_updateCallback;
         RenderCallback m_renderCallback;
+        float m_deltaTime = 0.0f;
+        double m_elapsedTime = 0.0;
+        int m_targetFrameRate = 60;
     };
 
 } // namespace WidgeCraft
-

--- a/include/WidgeCraft/Widget.hpp
+++ b/include/WidgeCraft/Widget.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "WidgeCraft/Input.hpp"
 #include "WidgeCraft/TextRenderer.hpp"
 #include "WidgeCraft/Types.hpp"
 
+#include <functional>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -12,15 +15,28 @@ namespace WidgeCraft {
 
     class Frame;
     class ShapeRenderer;
+
+    enum class HorizontalAlignment {
+        Left,
+        Center,
+        Right
+    };
+
     class Widget {
     public:
         explicit Widget(std::string name);
         virtual ~Widget() = default;
 
+        Widget(const Widget&) = delete;
+        Widget& operator=(const Widget&) = delete;
+
         const std::string& getName() const { return m_name; }
 
-        void setVisible(bool visible);
+        void setVisible(bool visible) { m_visible = visible; }
         bool isVisible() const { return m_visible; }
+
+        void setEnabled(bool enabled) { m_enabled = enabled; }
+        bool isEnabled() const { return m_enabled; }
 
         void setPosition(float x, float y);
         void setPosition(const Position& position) { setPosition(position.x, position.y); }
@@ -28,12 +44,17 @@ namespace WidgeCraft {
 
         void setSize(float width, float height);
         void setSize(const Size& size) { setSize(size.x, size.y); }
+        void clearExplicitSize() { m_hasExplicitSize = false; }
         Size getSize() const { return m_size; }
         bool hasExplicitSize() const { return m_hasExplicitSize; }
 
-        Frame* getParent() const { return m_parent; }
+        void setAnchor(Anchor anchor) { m_anchor = anchor; }
+        Anchor getAnchor() const { return m_anchor; }
 
-        virtual void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) = 0;
+        Frame* getParent() const { return m_parent; }
+        Rect getAbsoluteRect() const;
+
+        virtual void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer, const Input& input) = 0;
 
         friend class Frame;
         friend class Widgets;
@@ -41,14 +62,17 @@ namespace WidgeCraft {
     protected:
         void setParent(Frame* parent);
         void setComputedSize(float width, float height);
+        Rect resolveRect(const Frame& frame, const Size& desiredSize) const;
 
     private:
         std::string m_name;
         Frame* m_parent = nullptr;
         bool m_visible = true;
+        bool m_enabled = true;
         Position m_position{};
         Size m_size{};
         bool m_hasExplicitSize = false;
+        Anchor m_anchor = Anchor::BottomLeft;
     };
 
     class Widgets {
@@ -58,12 +82,14 @@ namespace WidgeCraft {
         template <typename T, typename... Args>
         T& emplace(Args&&... args);
 
+        Widget* find(const std::string& name);
+        const Widget* find(const std::string& name) const;
+        bool remove(const std::string& name);
+
         auto begin() { return m_widgets.begin(); }
         auto end() { return m_widgets.end(); }
         auto begin() const { return m_widgets.begin(); }
         auto end() const { return m_widgets.end(); }
-        auto cbegin() const { return m_widgets.cbegin(); }
-        auto cend() const { return m_widgets.cend(); }
 
         std::vector<std::unique_ptr<Widget>>& getAll() { return m_widgets; }
         const std::vector<std::unique_ptr<Widget>>& getAll() const { return m_widgets; }
@@ -77,55 +103,103 @@ namespace WidgeCraft {
     public:
         Label(std::string name, std::string text = "");
 
-        void setText(std::string text);
+        void setText(std::string text) { m_text = std::move(text); }
         const std::string& getText() const { return m_text; }
 
-        void setColor(TextRenderer::Color color) { m_color = color; }
-        TextRenderer::Color getColor() const { return m_color; }
+        void setColor(Color color) { m_color = color; }
+        Color getColor() const { return m_color; }
 
         void setTextSize(float sizePixels) { m_textSizePixels = sizePixels; }
         float getTextSize() const { return m_textSizePixels; }
 
-        void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) override;
+        void setAlignment(HorizontalAlignment alignment) { m_alignment = alignment; }
+        HorizontalAlignment getAlignment() const { return m_alignment; }
+
+        void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer, const Input& input) override;
 
     private:
         std::string m_text;
-        TextRenderer::Color m_color{ 1.0f, 1.0f, 1.0f };
+        Color m_color{ Colors::White };
         float m_textSizePixels = 0.0f;
+        HorizontalAlignment m_alignment = HorizontalAlignment::Left;
     };
 
     class Button : public Widget {
     public:
+        using ClickCallback = std::function<void()>;
+
         Button(std::string name, std::string text = "");
 
-        void setText(std::string text);
+        void setText(std::string text) { m_text = std::move(text); }
         const std::string& getText() const { return m_text; }
 
-        void setTextColor(TextRenderer::Color color) { m_textColor = color; }
-        TextRenderer::Color getTextColor() const { return m_textColor; }
-
+        void setTextColor(Color color) { m_textColor = color; }
+        Color getTextColor() const { return m_textColor; }
         void setTextSize(float sizePixels) { m_textSizePixels = sizePixels; }
-        float getTextSize() const { return m_textSizePixels; }
 
         void setBackgroundVisible(bool visible) { m_showBackground = visible; }
-        bool isBackgroundVisible() const { return m_showBackground; }
-
         void setBackgroundColor(Color color) { m_backgroundColor = color; }
-        Color getBackgroundColor() const { return m_backgroundColor; }
+        void setHoverColor(Color color) { m_hoverColor = color; }
+        void setPressedColor(Color color) { m_pressedColor = color; }
+        void setDisabledColor(Color color) { m_disabledColor = color; }
+        void setBorderColor(Color color) { m_borderColor = color; }
+        void setBorderVisible(bool visible) { m_showBorder = visible; }
+        void setPadding(float horizontal, float vertical);
 
-        void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) override;
+        void setOnClick(ClickCallback callback) { m_onClick = std::move(callback); }
+        bool isHovered() const { return m_hovered; }
+        bool isPressed() const { return m_pressed; }
+
+        void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer, const Input& input) override;
 
     private:
         std::string m_text;
-        TextRenderer::Color m_textColor{ 1.0f, 1.0f, 1.0f };
+        Color m_textColor{ Colors::White };
+        Color m_backgroundColor{ 0.20f, 0.24f, 0.30f, 1.0f };
+        Color m_hoverColor{ 0.27f, 0.34f, 0.43f, 1.0f };
+        Color m_pressedColor{ 0.13f, 0.17f, 0.23f, 1.0f };
+        Color m_disabledColor{ 0.20f, 0.20f, 0.20f, 0.65f };
+        Color m_borderColor{ 0.55f, 0.65f, 0.78f, 1.0f };
         float m_textSizePixels = 0.0f;
+        float m_horizontalPadding = 12.0f;
+        float m_verticalPadding = 7.0f;
         bool m_showBackground = true;
-        Color m_backgroundColor{ Colors::Grey };
+        bool m_showBorder = true;
+        bool m_hovered = false;
+        bool m_pressed = false;
+        bool m_armed = false;
+        ClickCallback m_onClick;
+    };
+
+    class Checkbox : public Widget {
+    public:
+        using ChangeCallback = std::function<void(bool)>;
+
+        Checkbox(std::string name, std::string text = "", bool checked = false);
+
+        void setText(std::string text) { m_text = std::move(text); }
+        const std::string& getText() const { return m_text; }
+        void setChecked(bool checked) { m_checked = checked; }
+        bool isChecked() const { return m_checked; }
+        void setTextSize(float sizePixels) { m_textSizePixels = sizePixels; }
+        void setOnChanged(ChangeCallback callback) { m_onChanged = std::move(callback); }
+
+        void render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer, const Input& input) override;
+
+    private:
+        std::string m_text;
+        bool m_checked = false;
+        bool m_armed = false;
+        float m_textSizePixels = 0.0f;
+        ChangeCallback m_onChanged;
     };
 
     template <typename T, typename... Args>
     T& Widgets::emplace(Args&&... args) {
         auto widget = std::make_unique<T>(std::forward<Args>(args)...);
+        if (find(widget->getName())) {
+            throw std::invalid_argument("A widget named '" + widget->getName() + "' already exists in this frame");
+        }
         widget->setParent(&m_owner);
         T& reference = *widget;
         m_widgets.emplace_back(std::move(widget));
@@ -133,4 +207,3 @@ namespace WidgeCraft {
     }
 
 } // namespace WidgeCraft
-

--- a/include/WidgeCraft/Window.hpp
+++ b/include/WidgeCraft/Window.hpp
@@ -1,9 +1,10 @@
 #pragma once
+
 #include "WidgeCraft/Frame.hpp"
+#include "WidgeCraft/Input.hpp"
 
 #include <string>
 
-// Forward declaration of GLFW window type
 struct GLFWwindow;
 
 namespace WidgeCraft {
@@ -13,25 +14,44 @@ namespace WidgeCraft {
         Window(int width, int height, const std::string& title);
         ~Window();
 
-        bool shouldClose() const;
-        void pollEvents() const;
+        Window(const Window&) = delete;
+        Window& operator=(const Window&) = delete;
 
-        // Needed so we can swap buffers in main
+        bool shouldClose() const;
+        void requestClose();
+        void pollEvents();
+        void swapBuffers() const;
+
+        void setVSync(bool enabled);
+        bool isVSyncEnabled() const { return m_vsyncEnabled; }
+        void setTitle(const std::string& title);
+
         GLFWwindow* getNativeHandle() const { return m_window; }
         int getWidth() const { return m_width; }
         int getHeight() const { return m_height; }
+        float getAspectRatio() const;
+
+        Input& getInput() { return m_input; }
+        const Input& getInput() const { return m_input; }
 
         Frame& getRootFrame() { return m_rootFrame; }
         const Frame& getRootFrame() const { return m_rootFrame; }
 
     private:
-        GLFWwindow* m_window;
-        int m_width;
-        int m_height;
+        GLFWwindow* m_window = nullptr;
+        int m_width = 0;
+        int m_height = 0;
+        bool m_vsyncEnabled = true;
+        Input m_input;
         Frame m_rootFrame;
 
         void updateSize(int width, int height);
+
         static void framebufferSizeCallback(GLFWwindow* window, int width, int height);
+        static void keyCallback(GLFWwindow* window, int key, int scanCode, int action, int modifiers);
+        static void mouseButtonCallback(GLFWwindow* window, int button, int action, int modifiers);
+        static void cursorPositionCallback(GLFWwindow* window, double x, double y);
+        static void scrollCallback(GLFWwindow* window, double xOffset, double yOffset);
     };
 
 } // namespace WidgeCraft

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -1,21 +1,39 @@
 #include "WidgeCraft/Frame.hpp"
 
 #include "WidgeCraft/ShapeRenderer.hpp"
-#include "WidgeCraft/TextRenderer.hpp"
+
+#include <glad/glad.h>
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 namespace WidgeCraft {
+
+    namespace {
+        void applyScissor(const Rect& clip) {
+            const int x = static_cast<int>(std::floor(clip.x));
+            const int y = static_cast<int>(std::floor(clip.y));
+            const int right = static_cast<int>(std::ceil(clip.right()));
+            const int top = static_cast<int>(std::ceil(clip.top()));
+            glEnable(GL_SCISSOR_TEST);
+            glScissor(x, y, std::max(0, right - x), std::max(0, top - y));
+        }
+    } // namespace
+
     Frame::Frame(std::string name, Frame* parent)
-        : m_name(std::move(name)), m_parent(parent), m_widgets(*this) {
+        : m_name(std::move(name))
+        , m_parent(parent)
+        , m_widgets(*this) {
+        if (m_name.empty()) {
+            throw std::invalid_argument("Frame names cannot be empty");
+        }
     }
 
     void Frame::setVisible(bool visible) {
         if (m_visible == visible) {
             return;
         }
-
         m_visible = visible;
         if (!m_visible) {
             clearTextBatchesRecursive();
@@ -23,13 +41,11 @@ namespace WidgeCraft {
     }
 
     void Frame::setPosition(float x, float y) {
-        m_position.x = x;
-        m_position.y = y;
+        m_position = { x, y };
     }
 
     void Frame::setSize(float width, float height) {
-        m_size.x = width;
-        m_size.y = height;
+        m_size = { std::max(0.0f, width), std::max(0.0f, height) };
     }
 
     Position Frame::getAbsolutePosition() const {
@@ -37,113 +53,165 @@ namespace WidgeCraft {
             return m_position;
         }
 
-        const Position parentPosition = m_parent->getAbsolutePosition();
-        const Size parentSize = m_parent->getSize();
-        Position result = parentPosition;
-
+        const Rect parentRect = m_parent->getAbsoluteRect();
+        Position result{ parentRect.x, parentRect.y };
         switch (m_anchor) {
         case Anchor::TopLeft:
             result.x += m_position.x;
-            result.y += parentSize.y - m_position.y - m_size.y;
+            result.y += parentRect.height - m_position.y - m_size.y;
             break;
         case Anchor::TopCenter:
-            result.x += (parentSize.x - m_size.x) * 0.5f + m_position.x;
-            result.y += parentSize.y - m_position.y - m_size.y;
+            result.x += (parentRect.width - m_size.x) * 0.5f + m_position.x;
+            result.y += parentRect.height - m_position.y - m_size.y;
             break;
         case Anchor::TopRight:
-            result.x += parentSize.x - m_position.x - m_size.x;
-            result.y += parentSize.y - m_position.y - m_size.y;
+            result.x += parentRect.width - m_position.x - m_size.x;
+            result.y += parentRect.height - m_position.y - m_size.y;
             break;
         case Anchor::CenterLeft:
             result.x += m_position.x;
-            result.y += (parentSize.y - m_size.y) * 0.5f + m_position.y;
+            result.y += (parentRect.height - m_size.y) * 0.5f + m_position.y;
             break;
         case Anchor::Center:
-            result.x += (parentSize.x - m_size.x) * 0.5f;
-            result.y += (parentSize.y - m_size.y) * 0.5f;
+            result.x += (parentRect.width - m_size.x) * 0.5f + m_position.x;
+            result.y += (parentRect.height - m_size.y) * 0.5f + m_position.y;
             break;
         case Anchor::CenterRight:
-            result.x += parentSize.x - m_position.x - m_size.x;
-            result.y += (parentSize.y - m_size.y) * 0.5f + m_position.y;
+            result.x += parentRect.width - m_position.x - m_size.x;
+            result.y += (parentRect.height - m_size.y) * 0.5f + m_position.y;
             break;
         case Anchor::BottomLeft:
             result.x += m_position.x;
             result.y += m_position.y;
             break;
         case Anchor::BottomCenter:
-            result.x += (parentSize.x - m_size.x) * 0.5f + m_position.x;
+            result.x += (parentRect.width - m_size.x) * 0.5f + m_position.x;
             result.y += m_position.y;
             break;
         case Anchor::BottomRight:
-            result.x += parentSize.x - m_position.x - m_size.x;
+            result.x += parentRect.width - m_position.x - m_size.x;
             result.y += m_position.y;
             break;
         }
-
         return result;
     }
 
+    Rect Frame::getAbsoluteRect() const {
+        const Position position = getAbsolutePosition();
+        return { position.x, position.y, m_size.x, m_size.y };
+    }
+
     Frame& Frame::createChildFrame(const std::string& name) {
+        if (findChildFrame(name)) {
+            throw std::invalid_argument("A child frame named '" + name + "' already exists in frame '" + m_name + "'");
+        }
+
         auto child = std::make_unique<Frame>(name, this);
         Frame& reference = *child;
         m_children.emplace_back(std::move(child));
         return reference;
     }
 
-    bool Frame::removeChildFrame(const std::string& name) {
-        auto it = std::find_if(m_children.begin(), m_children.end(), [&](const std::unique_ptr<Frame>& frame) {
+    Frame* Frame::findChildFrame(const std::string& name) {
+        const auto iterator = std::find_if(m_children.begin(), m_children.end(), [&](const auto& frame) {
             return frame && frame->getName() == name;
         });
+        return iterator != m_children.end() ? iterator->get() : nullptr;
+    }
 
-        if (it == m_children.end() || !(*it)->canBeDeleted()) {
+    const Frame* Frame::findChildFrame(const std::string& name) const {
+        const auto iterator = std::find_if(m_children.begin(), m_children.end(), [&](const auto& frame) {
+            return frame && frame->getName() == name;
+        });
+        return iterator != m_children.end() ? iterator->get() : nullptr;
+    }
+
+    bool Frame::removeChildFrame(const std::string& name) {
+        const auto iterator = std::find_if(m_children.begin(), m_children.end(), [&](const auto& frame) {
+            return frame && frame->getName() == name;
+        });
+        if (iterator == m_children.end() || !(*iterator)->canBeDeleted()) {
             return false;
         }
-
-        m_children.erase(it);
+        m_children.erase(iterator);
         return true;
     }
 
-    void Frame::render(TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) {
+    void Frame::render(TextRenderer& textRenderer, ShapeRenderer& shapeRenderer, const Input& input) {
+        const Rect rootClip = getAbsoluteRect();
+        renderInternal(textRenderer, shapeRenderer, input, rootClip, true);
+    }
+
+    void Frame::renderInternal(
+        TextRenderer& textRenderer,
+        ShapeRenderer& shapeRenderer,
+        const Input& input,
+        const Rect& parentClip,
+        bool isRoot) {
+
         if (!m_visible) {
             clearTextBatchesRecursive();
             return;
         }
 
-        const Position basePosition = getAbsolutePosition();
-        if (m_showBackground && m_size.x > 0.0f && m_size.y > 0.0f) {
-            shapeRenderer.drawFilledRect(basePosition.x, basePosition.y, m_size.x, m_size.y, m_backgroundColor);
+        const Rect frameRect = getAbsoluteRect();
+        const Rect activeClip = m_clipContents ? intersect(parentClip, frameRect) : parentClip;
+        if (activeClip.width <= 0.0f || activeClip.height <= 0.0f) {
+            clearTextBatchesRecursive();
+            return;
+        }
+
+        shapeRenderer.flush();
+        textRenderer.flush();
+        applyScissor(activeClip);
+
+        if (m_showBackground && frameRect.width > 0.0f && frameRect.height > 0.0f) {
+            shapeRenderer.drawFilledRect(frameRect.x, frameRect.y, frameRect.width, frameRect.height, m_backgroundColor);
         }
 
         for (const auto& widget : m_widgets) {
             if (widget && widget->isVisible()) {
-                widget->render(*this, textRenderer, shapeRenderer);
+                widget->render(*this, textRenderer, shapeRenderer, input);
             }
         }
 
         for (const auto& command : m_textBatch.getCommands()) {
-            float size = command.sizePixels;
-            if (size <= 0.0f) {
-                size = textRenderer.getBasePixelHeight();
-            }
-
+            const float size = command.sizePixels > 0.0f ? command.sizePixels : textRenderer.getBasePixelHeight();
             textRenderer.renderText(
                 command.text,
-                basePosition.x + command.position.x,
-                basePosition.y + command.position.y,
+                frameRect.x + command.position.x,
+                frameRect.y + command.position.y,
                 size,
                 command.color);
         }
-
         m_textBatch.clear();
+
+        if (m_showBorder && frameRect.width > 0.0f && frameRect.height > 0.0f && m_borderThickness > 0.0f) {
+            shapeRenderer.drawRectOutline(
+                frameRect.x,
+                frameRect.y,
+                frameRect.width,
+                frameRect.height,
+                m_borderThickness,
+                m_borderColor);
+        }
+
+        // Shape geometry must land before glyphs at each retained UI layer.
+        shapeRenderer.flush();
+        textRenderer.flush();
 
         for (auto& child : m_children) {
             if (child) {
-                child->render(textRenderer, shapeRenderer);
+                child->renderInternal(textRenderer, shapeRenderer, input, activeClip, false);
             }
         }
 
-        if (m_showBorder && m_size.x > 0.0f && m_size.y > 0.0f) {
-            shapeRenderer.drawRectOutline(basePosition.x, basePosition.y, m_size.x, m_size.y, 2.0f, Colors::Black);
+        shapeRenderer.flush();
+        textRenderer.flush();
+        if (isRoot) {
+            glDisable(GL_SCISSOR_TEST);
+        } else {
+            applyScissor(parentClip);
         }
     }
 
@@ -156,30 +224,8 @@ namespace WidgeCraft {
         }
     }
 
-    Frame* Frame::getRoot() {
-        Frame* current = this;
-        while (current && current->m_parent) {
-            current = current->m_parent;
-        }
-        return current;
-    }
-
-    const Frame* Frame::getRoot() const {
-        const Frame* current = this;
-        while (current && current->m_parent) {
-            current = current->m_parent;
-        }
-        return current;
-    }
-
-    void Frame::TextBatch::addText(std::string text, float x, float y, float sizePixels, TextRenderer::Color color) {
-        Command command;
-        command.text = std::move(text);
-        command.position.x = x;
-        command.position.y = y;
-        command.sizePixels = sizePixels;
-        command.color = color;
-        m_commands.emplace_back(std::move(command));
+    void Frame::TextBatch::addText(std::string text, float x, float y, float sizePixels, Color color) {
+        m_commands.push_back({ std::move(text), { x, y }, sizePixels, color });
     }
 
     void Frame::TextBatch::clear() {

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -1,0 +1,78 @@
+#include "WidgeCraft/Input.hpp"
+
+#include <algorithm>
+
+namespace WidgeCraft {
+
+    namespace {
+        bool validIndex(int index, int maximum) {
+            return index >= 0 && index < maximum;
+        }
+    }
+
+    void Input::beginFrame() {
+        m_previousKeys = m_keys;
+        m_previousMouseButtons = m_mouseButtons;
+        m_previousMousePosition = m_mousePosition;
+        m_mouseDelta = {};
+        m_scrollDelta = {};
+    }
+
+    bool Input::keyDown(int key) const {
+        return validIndex(key, MaxKeys) && m_keys[static_cast<std::size_t>(key)];
+    }
+
+    bool Input::keyPressed(int key) const {
+        return validIndex(key, MaxKeys)
+            && m_keys[static_cast<std::size_t>(key)]
+            && !m_previousKeys[static_cast<std::size_t>(key)];
+    }
+
+    bool Input::keyReleased(int key) const {
+        return validIndex(key, MaxKeys)
+            && !m_keys[static_cast<std::size_t>(key)]
+            && m_previousKeys[static_cast<std::size_t>(key)];
+    }
+
+    bool Input::mouseDown(MouseButton button) const {
+        const int index = static_cast<int>(button);
+        return validIndex(index, MaxMouseButtons) && m_mouseButtons[static_cast<std::size_t>(index)];
+    }
+
+    bool Input::mousePressed(MouseButton button) const {
+        const int index = static_cast<int>(button);
+        return validIndex(index, MaxMouseButtons)
+            && m_mouseButtons[static_cast<std::size_t>(index)]
+            && !m_previousMouseButtons[static_cast<std::size_t>(index)];
+    }
+
+    bool Input::mouseReleased(MouseButton button) const {
+        const int index = static_cast<int>(button);
+        return validIndex(index, MaxMouseButtons)
+            && !m_mouseButtons[static_cast<std::size_t>(index)]
+            && m_previousMouseButtons[static_cast<std::size_t>(index)];
+    }
+
+    void Input::setKey(int key, bool down) {
+        if (validIndex(key, MaxKeys)) {
+            m_keys[static_cast<std::size_t>(key)] = down;
+        }
+    }
+
+    void Input::setMouseButton(int button, bool down) {
+        if (validIndex(button, MaxMouseButtons)) {
+            m_mouseButtons[static_cast<std::size_t>(button)] = down;
+        }
+    }
+
+    void Input::setMousePosition(float x, float y) {
+        const Vec2 next{ x, y };
+        m_mouseDelta += next - m_mousePosition;
+        m_mousePosition = next;
+    }
+
+    void Input::addScroll(float x, float y) {
+        m_scrollDelta += Vec2{ x, y };
+    }
+
+} // namespace WidgeCraft

--- a/src/Raycast.cpp
+++ b/src/Raycast.cpp
@@ -1,0 +1,278 @@
+#include "WidgeCraft/Raycast.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+
+namespace WidgeCraft {
+
+    namespace {
+        constexpr float kEpsilon = 1.0e-6f;
+
+        Vec3 divideByW(const Vec4& value) {
+            if (std::abs(value.w) <= kEpsilon) {
+                return { value.x, value.y, value.z };
+            }
+            return { value.x / value.w, value.y / value.w, value.z / value.w };
+        }
+    } // namespace
+
+    bool invert(const Mat4& matrix, Mat4& inverseMatrix) {
+        std::array<std::array<float, 8>, 4> augmented{};
+
+        for (int row = 0; row < 4; ++row) {
+            for (int column = 0; column < 4; ++column) {
+                augmented[static_cast<std::size_t>(row)][static_cast<std::size_t>(column)] = matrix(row, column);
+            }
+            augmented[static_cast<std::size_t>(row)][static_cast<std::size_t>(row + 4)] = 1.0f;
+        }
+
+        for (int pivotColumn = 0; pivotColumn < 4; ++pivotColumn) {
+            int pivotRow = pivotColumn;
+            float pivotMagnitude = std::abs(augmented[static_cast<std::size_t>(pivotRow)][static_cast<std::size_t>(pivotColumn)]);
+
+            for (int row = pivotColumn + 1; row < 4; ++row) {
+                const float candidate = std::abs(augmented[static_cast<std::size_t>(row)][static_cast<std::size_t>(pivotColumn)]);
+                if (candidate > pivotMagnitude) {
+                    pivotMagnitude = candidate;
+                    pivotRow = row;
+                }
+            }
+
+            if (pivotMagnitude <= kEpsilon) {
+                inverseMatrix = Mat4::identity();
+                return false;
+            }
+
+            if (pivotRow != pivotColumn) {
+                std::swap(augmented[static_cast<std::size_t>(pivotRow)], augmented[static_cast<std::size_t>(pivotColumn)]);
+            }
+
+            const float pivot = augmented[static_cast<std::size_t>(pivotColumn)][static_cast<std::size_t>(pivotColumn)];
+            for (float& value : augmented[static_cast<std::size_t>(pivotColumn)]) {
+                value /= pivot;
+            }
+
+            for (int row = 0; row < 4; ++row) {
+                if (row == pivotColumn) {
+                    continue;
+                }
+
+                const float factor = augmented[static_cast<std::size_t>(row)][static_cast<std::size_t>(pivotColumn)];
+                for (int column = 0; column < 8; ++column) {
+                    augmented[static_cast<std::size_t>(row)][static_cast<std::size_t>(column)] -=
+                        factor * augmented[static_cast<std::size_t>(pivotColumn)][static_cast<std::size_t>(column)];
+                }
+            }
+        }
+
+        for (int row = 0; row < 4; ++row) {
+            for (int column = 0; column < 4; ++column) {
+                inverseMatrix(row, column) = augmented[static_cast<std::size_t>(row)][static_cast<std::size_t>(column + 4)];
+            }
+        }
+        return true;
+    }
+
+    bool raycast(const Ray& ray, const Sphere& sphere, RayHit& hit) {
+        if (sphere.radius <= 0.0f) {
+            return false;
+        }
+
+        const Vec3 offset = ray.origin - sphere.center;
+        const float a = dot(ray.direction, ray.direction);
+        if (a <= kEpsilon) {
+            return false;
+        }
+
+        const float halfB = dot(offset, ray.direction);
+        const float c = dot(offset, offset) - sphere.radius * sphere.radius;
+        const float discriminant = halfB * halfB - a * c;
+        if (discriminant < 0.0f) {
+            return false;
+        }
+
+        const float root = std::sqrt(discriminant);
+        float distance = (-halfB - root) / a;
+        if (distance < 0.0f) {
+            distance = (-halfB + root) / a;
+        }
+        if (distance < 0.0f) {
+            return false;
+        }
+
+        hit.distance = distance;
+        hit.point = ray.pointAt(distance);
+        hit.normal = normalized(hit.point - sphere.center);
+        hit.u = 0.0f;
+        hit.v = 0.0f;
+        return true;
+    }
+
+    bool raycast(const Ray& ray, const AABB& box, RayHit& hit) {
+        float nearDistance = 0.0f;
+        float farDistance = std::numeric_limits<float>::max();
+        Vec3 nearNormal{};
+        Vec3 farNormal{};
+
+        const float origins[3] = { ray.origin.x, ray.origin.y, ray.origin.z };
+        const float directions[3] = { ray.direction.x, ray.direction.y, ray.direction.z };
+        const float minimums[3] = { box.minimum.x, box.minimum.y, box.minimum.z };
+        const float maximums[3] = { box.maximum.x, box.maximum.y, box.maximum.z };
+
+        for (int axis = 0; axis < 3; ++axis) {
+            if (std::abs(directions[axis]) <= kEpsilon) {
+                if (origins[axis] < minimums[axis] || origins[axis] > maximums[axis]) {
+                    return false;
+                }
+                continue;
+            }
+
+            float axisNear = (minimums[axis] - origins[axis]) / directions[axis];
+            float axisFar = (maximums[axis] - origins[axis]) / directions[axis];
+
+            Vec3 negativeNormal{};
+            Vec3 positiveNormal{};
+            if (axis == 0) {
+                negativeNormal = { -1.0f, 0.0f, 0.0f };
+                positiveNormal = { 1.0f, 0.0f, 0.0f };
+            } else if (axis == 1) {
+                negativeNormal = { 0.0f, -1.0f, 0.0f };
+                positiveNormal = { 0.0f, 1.0f, 0.0f };
+            } else {
+                negativeNormal = { 0.0f, 0.0f, -1.0f };
+                positiveNormal = { 0.0f, 0.0f, 1.0f };
+            }
+
+            Vec3 axisNearNormal = negativeNormal;
+            Vec3 axisFarNormal = positiveNormal;
+            if (axisNear > axisFar) {
+                std::swap(axisNear, axisFar);
+                std::swap(axisNearNormal, axisFarNormal);
+            }
+
+            if (axisNear > nearDistance) {
+                nearDistance = axisNear;
+                nearNormal = axisNearNormal;
+            }
+            if (axisFar < farDistance) {
+                farDistance = axisFar;
+                farNormal = axisFarNormal;
+            }
+
+            if (nearDistance > farDistance) {
+                return false;
+            }
+        }
+
+        const bool startedInside = nearDistance <= kEpsilon;
+        const float distance = startedInside ? farDistance : nearDistance;
+        if (distance < 0.0f || !std::isfinite(distance)) {
+            return false;
+        }
+
+        hit.distance = distance;
+        hit.point = ray.pointAt(distance);
+        hit.normal = startedInside ? farNormal : nearNormal;
+        hit.u = 0.0f;
+        hit.v = 0.0f;
+        return true;
+    }
+
+    bool raycast(const Ray& ray, const Plane& plane, RayHit& hit) {
+        const Vec3 normal = normalized(plane.normal);
+        if (lengthSquared(normal) <= kEpsilon) {
+            return false;
+        }
+
+        const float denominator = dot(normal, ray.direction);
+        if (std::abs(denominator) <= kEpsilon) {
+            return false;
+        }
+
+        const float distance = -(dot(normal, ray.origin) + plane.distance) / denominator;
+        if (distance < 0.0f) {
+            return false;
+        }
+
+        hit.distance = distance;
+        hit.point = ray.pointAt(distance);
+        hit.normal = denominator < 0.0f ? normal : -normal;
+        hit.u = 0.0f;
+        hit.v = 0.0f;
+        return true;
+    }
+
+    bool raycast(const Ray& ray, const Triangle& triangle, RayHit& hit, bool cullBackFaces) {
+        const Vec3 edge1 = triangle.b - triangle.a;
+        const Vec3 edge2 = triangle.c - triangle.a;
+        const Vec3 p = cross(ray.direction, edge2);
+        const float determinant = dot(edge1, p);
+
+        if (cullBackFaces) {
+            if (determinant <= kEpsilon) {
+                return false;
+            }
+        } else if (std::abs(determinant) <= kEpsilon) {
+            return false;
+        }
+
+        const float inverseDeterminant = 1.0f / determinant;
+        const Vec3 offset = ray.origin - triangle.a;
+        const float u = dot(offset, p) * inverseDeterminant;
+        if (u < 0.0f || u > 1.0f) {
+            return false;
+        }
+
+        const Vec3 q = cross(offset, edge1);
+        const float v = dot(ray.direction, q) * inverseDeterminant;
+        if (v < 0.0f || u + v > 1.0f) {
+            return false;
+        }
+
+        const float distance = dot(edge2, q) * inverseDeterminant;
+        if (distance < 0.0f) {
+            return false;
+        }
+
+        Vec3 normal = normalized(cross(edge1, edge2));
+        if (dot(normal, ray.direction) > 0.0f) {
+            normal = -normal;
+        }
+
+        hit.distance = distance;
+        hit.point = ray.pointAt(distance);
+        hit.normal = normal;
+        hit.u = u;
+        hit.v = v;
+        return true;
+    }
+
+    Ray screenPointToRay(
+        float screenX,
+        float screenY,
+        float viewportWidth,
+        float viewportHeight,
+        const Mat4& view,
+        const Mat4& projection) {
+
+        if (viewportWidth <= 0.0f || viewportHeight <= 0.0f) {
+            return {};
+        }
+
+        const float normalizedX = (screenX / viewportWidth) * 2.0f - 1.0f;
+        const float normalizedY = (screenY / viewportHeight) * 2.0f - 1.0f;
+
+        Mat4 inverseViewProjection{};
+        if (!invert(projection * view, inverseViewProjection)) {
+            return {};
+        }
+
+        const Vec3 nearPoint = divideByW(inverseViewProjection * Vec4{ normalizedX, normalizedY, -1.0f, 1.0f });
+        const Vec3 farPoint = divideByW(inverseViewProjection * Vec4{ normalizedX, normalizedY, 1.0f, 1.0f });
+
+        return { nearPoint, normalized(farPoint - nearPoint) };
+    }
+
+} // namespace WidgeCraft

--- a/src/ShapeRenderer.cpp
+++ b/src/ShapeRenderer.cpp
@@ -1,49 +1,60 @@
 #include "WidgeCraft/ShapeRenderer.hpp"
 
+#include <glad/glad.h>
+
 #include <algorithm>
-#include <array>
+#include <cmath>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace {
 
+    constexpr float kPi = 3.14159265358979323846f;
+
     GLuint compileShader(GLenum type, const char* source) {
-        GLuint shader = glCreateShader(type);
+        const GLuint shader = glCreateShader(type);
         glShaderSource(shader, 1, &source, nullptr);
         glCompileShader(shader);
 
-        GLint status = 0;
+        GLint status = GL_FALSE;
         glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
         if (status == GL_FALSE) {
             GLint logLength = 0;
             glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
-            std::string log(static_cast<size_t>(logLength > 0 ? logLength : 1), '\0');
+            std::string log(static_cast<std::size_t>(std::max(logLength, 1)), '\0');
             glGetShaderInfoLog(shader, logLength, nullptr, log.data());
             glDeleteShader(shader);
-            throw std::runtime_error("Failed to compile rectangle shader: " + log);
+            throw std::runtime_error("Failed to compile shape shader: " + log);
         }
-
         return shader;
     }
 
     GLuint linkProgram(GLuint vertexShader, GLuint fragmentShader) {
-        GLuint program = glCreateProgram();
+        const GLuint program = glCreateProgram();
         glAttachShader(program, vertexShader);
         glAttachShader(program, fragmentShader);
         glLinkProgram(program);
 
-        GLint status = 0;
+        GLint status = GL_FALSE;
         glGetProgramiv(program, GL_LINK_STATUS, &status);
         if (status == GL_FALSE) {
             GLint logLength = 0;
             glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
-            std::string log(static_cast<size_t>(logLength > 0 ? logLength : 1), '\0');
+            std::string log(static_cast<std::size_t>(std::max(logLength, 1)), '\0');
             glGetProgramInfoLog(program, logLength, nullptr, log.data());
             glDeleteProgram(program);
-            throw std::runtime_error("Failed to link rectangle shader: " + log);
+            throw std::runtime_error("Failed to link shape shader: " + log);
         }
-
         return program;
+    }
+
+    int chooseCircleSegments(float radius, int requestedSegments) {
+        if (requestedSegments > 2) {
+            return requestedSegments;
+        }
+        return std::clamp(static_cast<int>(std::ceil(radius * 0.75f)), 12, 128);
     }
 
 } // namespace
@@ -51,33 +62,36 @@ namespace {
 namespace WidgeCraft {
 
     ShapeRenderer::ShapeRenderer() {
-        static constexpr char kVertexShaderSrc[] = R"(
+        static constexpr char kVertexShader[] = R"(
             #version 330 core
-            layout (location = 0) in vec2 aPos;
+            layout (location = 0) in vec2 aPosition;
+            layout (location = 1) in vec4 aColor;
 
             uniform vec2 uScreenSize;
+            out vec4 vColor;
 
             void main() {
-                vec2 normalized = vec2(
-                    (aPos.x / uScreenSize.x) * 2.0 - 1.0,
-                    (aPos.y / uScreenSize.y) * 2.0 - 1.0
+                vec2 ndc = vec2(
+                    (aPosition.x / uScreenSize.x) * 2.0 - 1.0,
+                    (aPosition.y / uScreenSize.y) * 2.0 - 1.0
                 );
-                gl_Position = vec4(normalized, 0.0, 1.0);
+                gl_Position = vec4(ndc, 0.0, 1.0);
+                vColor = aColor;
             }
         )";
 
-        static constexpr char kFragmentShaderSrc[] = R"(
+        static constexpr char kFragmentShader[] = R"(
             #version 330 core
-            uniform vec4 uColor;
-            out vec4 FragColor;
+            in vec4 vColor;
+            out vec4 fragColor;
 
             void main() {
-                FragColor = uColor;
+                fragColor = vColor;
             }
         )";
 
-        const GLuint vertexShader = compileShader(GL_VERTEX_SHADER, kVertexShaderSrc);
-        const GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, kFragmentShaderSrc);
+        const GLuint vertexShader = compileShader(GL_VERTEX_SHADER, kVertexShader);
+        const GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, kFragmentShader);
         m_shader = linkProgram(vertexShader, fragmentShader);
         glDeleteShader(vertexShader);
         glDeleteShader(fragmentShader);
@@ -87,13 +101,18 @@ namespace WidgeCraft {
 
         glBindVertexArray(m_vao);
         glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 8, nullptr, GL_DYNAMIC_DRAW);
+        glBufferData(GL_ARRAY_BUFFER, 0, nullptr, GL_DYNAMIC_DRAW);
+
         glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 2, reinterpret_cast<void*>(0));
+        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), reinterpret_cast<void*>(offsetof(Vertex, x)));
+        glEnableVertexAttribArray(1);
+        glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), reinterpret_cast<void*>(offsetof(Vertex, r)));
+
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
         glBindVertexArray(0);
 
         m_uniformScreenSize = glGetUniformLocation(m_shader, "uScreenSize");
-        m_uniformColor = glGetUniformLocation(m_shader, "uColor");
+        m_vertices.reserve(4096);
     }
 
     ShapeRenderer::~ShapeRenderer() {
@@ -112,20 +131,160 @@ namespace WidgeCraft {
         return *this;
     }
 
+    void ShapeRenderer::setScreenSize(float width, float height) {
+        m_screenWidth = width;
+        m_screenHeight = height;
+    }
+
+    void ShapeRenderer::beginFrame() {
+        m_vertices.clear();
+    }
+
+    void ShapeRenderer::flush() {
+        if (m_vertices.empty() || m_screenWidth <= 0.0f || m_screenHeight <= 0.0f) {
+            m_vertices.clear();
+            return;
+        }
+
+        glUseProgram(m_shader);
+        glUniform2f(m_uniformScreenSize, m_screenWidth, m_screenHeight);
+
+        glBindVertexArray(m_vao);
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glBufferData(
+            GL_ARRAY_BUFFER,
+            static_cast<GLsizeiptr>(m_vertices.size() * sizeof(Vertex)),
+            m_vertices.data(),
+            GL_DYNAMIC_DRAW);
+        glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(m_vertices.size()));
+
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glBindVertexArray(0);
+        glUseProgram(0);
+        m_vertices.clear();
+    }
+
+    void ShapeRenderer::reserve(std::size_t triangleCount) {
+        m_vertices.reserve(triangleCount * 3);
+    }
+
+    void ShapeRenderer::drawPoint(float x, float y, float size, const Color& color) {
+        if (size <= 0.0f) {
+            return;
+        }
+        drawFilledCircle(x, y, size * 0.5f, color);
+    }
+
+    void ShapeRenderer::drawLine(float x1, float y1, float x2, float y2, float thickness, const Color& color) {
+        if (thickness <= 0.0f) {
+            return;
+        }
+
+        const Vec2 start{ x1, y1 };
+        const Vec2 end{ x2, y2 };
+        const Vec2 delta = end - start;
+        const float segmentLength = length(delta);
+        if (segmentLength <= 1.0e-6f) {
+            drawPoint(x1, y1, thickness, color);
+            return;
+        }
+
+        const Vec2 normal{ -delta.y / segmentLength, delta.x / segmentLength };
+        const Vec2 offset = normal * (thickness * 0.5f);
+        const Vec2 a = start - offset;
+        const Vec2 b = start + offset;
+        const Vec2 c = end + offset;
+        const Vec2 d = end - offset;
+
+        drawTriangle(a, b, c, color);
+        drawTriangle(a, c, d, color);
+    }
+
+    void ShapeRenderer::drawTriangle(const Vec2& a, const Vec2& b, const Vec2& c, const Color& color) {
+        addVertex(a, color);
+        addVertex(b, color);
+        addVertex(c, color);
+    }
+
+    void ShapeRenderer::drawFilledRect(float x, float y, float width, float height, const Color& color) {
+        if (width <= 0.0f || height <= 0.0f) {
+            return;
+        }
+
+        const Vec2 bottomLeft{ x, y };
+        const Vec2 bottomRight{ x + width, y };
+        const Vec2 topRight{ x + width, y + height };
+        const Vec2 topLeft{ x, y + height };
+        drawTriangle(bottomLeft, bottomRight, topRight, color);
+        drawTriangle(bottomLeft, topRight, topLeft, color);
+    }
+
+    void ShapeRenderer::drawRectOutline(float x, float y, float width, float height, float thickness, const Color& color) {
+        if (width <= 0.0f || height <= 0.0f || thickness <= 0.0f) {
+            return;
+        }
+
+        const float clamped = std::min(thickness, std::min(width, height) * 0.5f);
+        drawFilledRect(x, y, width, clamped, color);
+        drawFilledRect(x, y + height - clamped, width, clamped, color);
+        drawFilledRect(x, y + clamped, clamped, height - clamped * 2.0f, color);
+        drawFilledRect(x + width - clamped, y + clamped, clamped, height - clamped * 2.0f, color);
+    }
+
+    void ShapeRenderer::drawFilledCircle(float centerX, float centerY, float radius, const Color& color, int segments) {
+        if (radius <= 0.0f) {
+            return;
+        }
+
+        const int segmentCount = chooseCircleSegments(radius, segments);
+        const Vec2 center{ centerX, centerY };
+        for (int index = 0; index < segmentCount; ++index) {
+            const float angle0 = (static_cast<float>(index) / static_cast<float>(segmentCount)) * (2.0f * kPi);
+            const float angle1 = (static_cast<float>(index + 1) / static_cast<float>(segmentCount)) * (2.0f * kPi);
+            const Vec2 a{ centerX + std::cos(angle0) * radius, centerY + std::sin(angle0) * radius };
+            const Vec2 b{ centerX + std::cos(angle1) * radius, centerY + std::sin(angle1) * radius };
+            drawTriangle(center, a, b, color);
+        }
+    }
+
+    void ShapeRenderer::drawCircleOutline(float centerX, float centerY, float radius, float thickness, const Color& color, int segments) {
+        if (radius <= 0.0f || thickness <= 0.0f) {
+            return;
+        }
+
+        const int segmentCount = chooseCircleSegments(radius, segments);
+        const float innerRadius = std::max(0.0f, radius - thickness);
+        for (int index = 0; index < segmentCount; ++index) {
+            const float angle0 = (static_cast<float>(index) / static_cast<float>(segmentCount)) * (2.0f * kPi);
+            const float angle1 = (static_cast<float>(index + 1) / static_cast<float>(segmentCount)) * (2.0f * kPi);
+
+            const Vec2 outer0{ centerX + std::cos(angle0) * radius, centerY + std::sin(angle0) * radius };
+            const Vec2 outer1{ centerX + std::cos(angle1) * radius, centerY + std::sin(angle1) * radius };
+            const Vec2 inner0{ centerX + std::cos(angle0) * innerRadius, centerY + std::sin(angle0) * innerRadius };
+            const Vec2 inner1{ centerX + std::cos(angle1) * innerRadius, centerY + std::sin(angle1) * innerRadius };
+
+            drawTriangle(inner0, outer0, outer1, color);
+            drawTriangle(inner0, outer1, inner1, color);
+        }
+    }
+
+    void ShapeRenderer::addVertex(const Vec2& position, const Color& color) {
+        m_vertices.push_back({ position.x, position.y, color.r, color.g, color.b, color.a });
+    }
+
     void ShapeRenderer::moveFrom(ShapeRenderer&& other) noexcept {
         m_vao = other.m_vao;
         m_vbo = other.m_vbo;
         m_shader = other.m_shader;
         m_uniformScreenSize = other.m_uniformScreenSize;
-        m_uniformColor = other.m_uniformColor;
         m_screenWidth = other.m_screenWidth;
         m_screenHeight = other.m_screenHeight;
+        m_vertices = std::move(other.m_vertices);
 
         other.m_vao = 0;
         other.m_vbo = 0;
         other.m_shader = 0;
         other.m_uniformScreenSize = -1;
-        other.m_uniformColor = -1;
         other.m_screenWidth = 0.0f;
         other.m_screenHeight = 0.0f;
     }
@@ -143,52 +302,7 @@ namespace WidgeCraft {
             glDeleteProgram(m_shader);
             m_shader = 0;
         }
-        m_uniformScreenSize = -1;
-        m_uniformColor = -1;
-        m_screenWidth = 0.0f;
-        m_screenHeight = 0.0f;
-    }
-
-    void ShapeRenderer::setScreenSize(float width, float height) {
-        m_screenWidth = width;
-        m_screenHeight = height;
-    }
-
-    void ShapeRenderer::drawFilledRect(float x, float y, float width, float height, const Color& color) const {
-        if (width <= 0.0f || height <= 0.0f || m_screenWidth <= 0.0f || m_screenHeight <= 0.0f) {
-            return;
-        }
-
-        const std::array<float, 8> vertices{
-            x, y,
-            x + width, y,
-            x, y + height,
-            x + width, y + height,
-        };
-
-        glUseProgram(m_shader);
-        glUniform2f(m_uniformScreenSize, m_screenWidth, m_screenHeight);
-        glUniform4f(m_uniformColor, color.r, color.g, color.b, color.a);
-
-        glBindVertexArray(m_vao);
-        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices.data());
-        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-        glBindVertexArray(0);
-    }
-
-    void ShapeRenderer::drawRectOutline(float x, float y, float width, float height, float thickness, const Color& color) const {
-        if (width <= 0.0f || height <= 0.0f || thickness <= 0.0f) {
-            return;
-        }
-
-        const float clampedThickness = std::min(thickness, std::min(width, height));
-
-        drawFilledRect(x, y, width, clampedThickness, color);
-        drawFilledRect(x, y + height - clampedThickness, width, clampedThickness, color);
-        drawFilledRect(x, y, clampedThickness, height, color);
-        drawFilledRect(x + width - clampedThickness, y, clampedThickness, height, color);
+        m_vertices.clear();
     }
 
 } // namespace WidgeCraft
-

--- a/src/TextRenderer.cpp
+++ b/src/TextRenderer.cpp
@@ -3,11 +3,14 @@
 #include <glad/glad.h>
 
 #include <algorithm>
-#include <limits>
+#include <cmath>
+#include <cstddef>
 #include <fstream>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -17,95 +20,176 @@
 namespace WidgeCraft {
 
     namespace {
-        constexpr int kAtlasSize = 1024;
-        constexpr int kFirstChar = 32;
-        constexpr int kLastChar = 126;
-        constexpr int kPadding = 6;
+        constexpr int kAtlasSize = 2048;
+        constexpr int kPadding = 8;
         constexpr unsigned char kOnEdgeValue = 180;
-        constexpr float kPixelDistScale = 64.0f;
+        constexpr float kPixelDistanceScale = 64.0f;
 
-        constexpr std::string_view kVertexShaderSrc = R"(
+        constexpr std::string_view kVertexShader = R"(
             #version 330 core
-            layout (location = 0) in vec2 aPos;
+            layout (location = 0) in vec2 aPosition;
             layout (location = 1) in vec2 aTexCoord;
+            layout (location = 2) in vec4 aColor;
 
             uniform mat4 uProjection;
 
             out vec2 vTexCoord;
+            out vec4 vColor;
 
             void main() {
+                gl_Position = uProjection * vec4(aPosition, 0.0, 1.0);
                 vTexCoord = aTexCoord;
-                gl_Position = uProjection * vec4(aPos, 0.0, 1.0);
+                vColor = aColor;
             }
         )";
 
-        constexpr std::string_view kFragmentShaderSrc = R"(
+        constexpr std::string_view kFragmentShader = R"(
             #version 330 core
             in vec2 vTexCoord;
+            in vec4 vColor;
 
             uniform sampler2D uTexture;
-            uniform vec3 uTextColor;
             uniform float uEdgeValue;
-            uniform float uSmoothing;
+            uniform float uSoftness;
 
-            out vec4 FragColor;
+            out vec4 fragColor;
 
             void main() {
-                float distance = texture(uTexture, vTexCoord).r;
-                vec2 gradient = vec2(dFdx(distance), dFdy(distance));
-                float coverageWidth = max(uSmoothing, 0.5 * length(gradient));
-                float alpha = smoothstep(uEdgeValue - coverageWidth, uEdgeValue + coverageWidth, distance);
-                FragColor = vec4(uTextColor, alpha);
+                float signedDistance = texture(uTexture, vTexCoord).r;
+                float antialiasWidth = max(fwidth(signedDistance) * uSoftness, 0.00075);
+                float alpha = smoothstep(
+                    uEdgeValue - antialiasWidth,
+                    uEdgeValue + antialiasWidth,
+                    signedDistance);
+                fragColor = vec4(vColor.rgb, vColor.a * alpha);
             }
         )";
 
         GLuint compileShader(GLenum type, std::string_view source) {
-            GLuint shader = glCreateShader(type);
-            const char* src = source.data();
-            GLint length = static_cast<GLint>(source.size());
-            glShaderSource(shader, 1, &src, &length);
+            const GLuint shader = glCreateShader(type);
+            const char* data = source.data();
+            const GLint length = static_cast<GLint>(source.size());
+            glShaderSource(shader, 1, &data, &length);
             glCompileShader(shader);
 
-            GLint status = 0;
+            GLint status = GL_FALSE;
             glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
             if (status == GL_FALSE) {
                 GLint logLength = 0;
                 glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
-                std::string log(static_cast<size_t>(logLength), '\0');
+                std::string log(static_cast<std::size_t>(std::max(logLength, 1)), '\0');
                 glGetShaderInfoLog(shader, logLength, nullptr, log.data());
                 glDeleteShader(shader);
-                throw std::runtime_error("Shader compilation failed: " + log);
+                throw std::runtime_error("SDF text shader compilation failed: " + log);
             }
-
             return shader;
         }
 
         GLuint linkProgram(GLuint vertexShader, GLuint fragmentShader) {
-            GLuint program = glCreateProgram();
+            const GLuint program = glCreateProgram();
             glAttachShader(program, vertexShader);
             glAttachShader(program, fragmentShader);
             glLinkProgram(program);
 
-            GLint status = 0;
+            GLint status = GL_FALSE;
             glGetProgramiv(program, GL_LINK_STATUS, &status);
             if (status == GL_FALSE) {
                 GLint logLength = 0;
                 glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
-                std::string log(static_cast<size_t>(logLength), '\0');
+                std::string log(static_cast<std::size_t>(std::max(logLength, 1)), '\0');
                 glGetProgramInfoLog(program, logLength, nullptr, log.data());
                 glDeleteProgram(program);
-                throw std::runtime_error("Shader linking failed: " + log);
+                throw std::runtime_error("SDF text shader linking failed: " + log);
+            }
+            return program;
+        }
+
+        std::vector<char32_t> decodeUtf8(std::string_view text) {
+            std::vector<char32_t> output;
+            output.reserve(text.size());
+
+            std::size_t index = 0;
+            while (index < text.size()) {
+                const auto first = static_cast<unsigned char>(text[index]);
+                if (first < 0x80U) {
+                    output.push_back(static_cast<char32_t>(first));
+                    ++index;
+                    continue;
+                }
+
+                int continuationCount = 0;
+                char32_t codepoint = 0;
+                if ((first & 0xE0U) == 0xC0U) {
+                    continuationCount = 1;
+                    codepoint = first & 0x1FU;
+                } else if ((first & 0xF0U) == 0xE0U) {
+                    continuationCount = 2;
+                    codepoint = first & 0x0FU;
+                } else if ((first & 0xF8U) == 0xF0U) {
+                    continuationCount = 3;
+                    codepoint = first & 0x07U;
+                } else {
+                    output.push_back(U'\uFFFD');
+                    ++index;
+                    continue;
+                }
+
+                if (index + static_cast<std::size_t>(continuationCount) >= text.size()) {
+                    output.push_back(U'\uFFFD');
+                    break;
+                }
+
+                bool valid = true;
+                for (int continuation = 1; continuation <= continuationCount; ++continuation) {
+                    const auto value = static_cast<unsigned char>(text[index + static_cast<std::size_t>(continuation)]);
+                    if ((value & 0xC0U) != 0x80U) {
+                        valid = false;
+                        break;
+                    }
+                    codepoint = (codepoint << 6U) | (value & 0x3FU);
+                }
+
+                const bool overlong =
+                    (continuationCount == 1 && codepoint < 0x80U)
+                    || (continuationCount == 2 && codepoint < 0x800U)
+                    || (continuationCount == 3 && codepoint < 0x10000U);
+                const bool invalidRange = codepoint > 0x10FFFFU || (codepoint >= 0xD800U && codepoint <= 0xDFFFU);
+
+                if (!valid || overlong || invalidRange) {
+                    output.push_back(U'\uFFFD');
+                    ++index;
+                    continue;
+                }
+
+                output.push_back(codepoint);
+                index += static_cast<std::size_t>(continuationCount + 1);
+            }
+            return output;
+        }
+
+        std::vector<char32_t> defaultCodepoints() {
+            std::vector<char32_t> codepoints;
+            codepoints.reserve(256);
+            for (char32_t codepoint = 32; codepoint <= 255; ++codepoint) {
+                codepoints.push_back(codepoint);
             }
 
-            return program;
+            const char32_t extras[] = {
+                U'\u2013', U'\u2014', U'\u2018', U'\u2019', U'\u201C', U'\u201D',
+                U'\u2022', U'\u2026', U'\u20AC', U'\u2190', U'\u2191', U'\u2192',
+                U'\u2193', U'\u2713', U'\u2715', U'\uFFFD'
+            };
+            codepoints.insert(codepoints.end(), std::begin(extras), std::end(extras));
+            return codepoints;
         }
 
     } // namespace
 
     TextRenderer::TextRenderer(int screenWidth, int screenHeight, const std::string& fontPath, float fontPixelHeight)
-        : m_fontInfo(std::make_unique<stbtt_fontinfo>()),
-          m_screenWidth(screenWidth),
-          m_screenHeight(screenHeight) {
+        : m_fontInfo(std::make_unique<stbtt_fontinfo>())
+        , m_screenWidth(screenWidth)
+        , m_screenHeight(screenHeight) {
+
         if (!loadFont(fontPath)) {
             throw std::runtime_error("Failed to load font: " + fontPath);
         }
@@ -115,6 +199,7 @@ namespace WidgeCraft {
         createBuffers();
         uploadAtlasTexture();
         updateProjection();
+        m_vertices.reserve(4096);
     }
 
     TextRenderer::~TextRenderer() {
@@ -131,6 +216,226 @@ namespace WidgeCraft {
             moveFrom(std::move(other));
         }
         return *this;
+    }
+
+    void TextRenderer::setScreenSize(int width, int height) {
+        if (m_screenWidth == width && m_screenHeight == height) {
+            return;
+        }
+        m_screenWidth = width;
+        m_screenHeight = height;
+        updateProjection();
+    }
+
+    void TextRenderer::beginFrame() {
+        m_vertices.clear();
+    }
+
+    void TextRenderer::flush() {
+        if (m_vertices.empty() || m_shader == 0 || m_texture == 0) {
+            m_vertices.clear();
+            return;
+        }
+
+        glUseProgram(m_shader);
+        glUniformMatrix4fv(m_uniformProjection, 1, GL_FALSE, m_projection.values.data());
+        glUniform1f(m_uniformEdgeValue, m_edgeValue);
+        glUniform1f(m_uniformSoftness, m_softness);
+
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, m_texture);
+        glBindVertexArray(m_vao);
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glBufferData(
+            GL_ARRAY_BUFFER,
+            static_cast<GLsizeiptr>(m_vertices.size() * sizeof(Vertex)),
+            m_vertices.data(),
+            GL_DYNAMIC_DRAW);
+        glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(m_vertices.size()));
+
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glBindVertexArray(0);
+        glBindTexture(GL_TEXTURE_2D, 0);
+        glUseProgram(0);
+        m_vertices.clear();
+    }
+
+    void TextRenderer::renderText(const std::string& text, float x, float y, float sizePixels, Color color) {
+        if (text.empty() || m_basePixelHeight <= 0.0f) {
+            return;
+        }
+        if (sizePixels <= 0.0f) {
+            sizePixels = m_basePixelHeight;
+        }
+        if (sizePixels <= 0.0f) {
+            return;
+        }
+
+        const std::vector<char32_t> codepoints = decodeUtf8(text);
+        const float sizeScale = sizePixels / m_basePixelHeight;
+        float cursorX = x;
+        float cursorY = y;
+
+        for (std::size_t index = 0; index < codepoints.size(); ++index) {
+            const char32_t codepoint = codepoints[index];
+            if (codepoint == U'\r') {
+                continue;
+            }
+            if (codepoint == U'\n') {
+                cursorX = x;
+                cursorY -= m_lineHeight * sizeScale;
+                continue;
+            }
+
+            const Glyph* glyph = findGlyph(codepoint);
+            if (!glyph) {
+                continue;
+            }
+
+            const float xPosition = cursorX + glyph->xOffset * sizeScale;
+            const float yPosition = cursorY - (glyph->yOffset + glyph->height) * sizeScale;
+            const float width = glyph->width * sizeScale;
+            const float height = glyph->height * sizeScale;
+
+            if (width > 0.0f && height > 0.0f) {
+                const Vertex bottomLeft{ xPosition, yPosition, glyph->u0, glyph->v0, color.r, color.g, color.b, color.a };
+                const Vertex bottomRight{ xPosition + width, yPosition, glyph->u1, glyph->v0, color.r, color.g, color.b, color.a };
+                const Vertex topRight{ xPosition + width, yPosition + height, glyph->u1, glyph->v1, color.r, color.g, color.b, color.a };
+                const Vertex topLeft{ xPosition, yPosition + height, glyph->u0, glyph->v1, color.r, color.g, color.b, color.a };
+
+                m_vertices.push_back(bottomLeft);
+                m_vertices.push_back(bottomRight);
+                m_vertices.push_back(topRight);
+                m_vertices.push_back(bottomLeft);
+                m_vertices.push_back(topRight);
+                m_vertices.push_back(topLeft);
+            }
+
+            cursorX += glyph->advance * sizeScale;
+
+            if (index + 1 < codepoints.size() && m_fontInfo) {
+                const char32_t nextCodepoint = codepoints[index + 1];
+                if (nextCodepoint != U'\n' && nextCodepoint != U'\r') {
+                    const Glyph* nextGlyph = findGlyph(nextCodepoint);
+                    if (nextGlyph) {
+                        const int kerning = stbtt_GetGlyphKernAdvance(
+                            m_fontInfo.get(),
+                            glyph->glyphIndex,
+                            nextGlyph->glyphIndex);
+                        cursorX += static_cast<float>(kerning) * m_scale * sizeScale;
+                    }
+                }
+            }
+        }
+    }
+
+    void TextRenderer::renderTextCentered(const std::string& text, float centerX, float centerY, float sizePixels, Color color) {
+        const auto bounds = measureTextBounds(text, sizePixels);
+        if (!bounds) {
+            return;
+        }
+
+        const float x = centerX - (bounds->minX + bounds->maxX) * 0.5f;
+        const float y = centerY - (bounds->minY + bounds->maxY) * 0.5f;
+        renderText(text, x, y, sizePixels, color);
+    }
+
+    std::optional<TextRenderer::TextBounds> TextRenderer::measureTextBounds(const std::string& text, float sizePixels) const {
+        if (text.empty() || m_basePixelHeight <= 0.0f) {
+            return std::nullopt;
+        }
+        if (sizePixels <= 0.0f) {
+            sizePixels = m_basePixelHeight;
+        }
+        if (sizePixels <= 0.0f) {
+            return std::nullopt;
+        }
+
+        const std::vector<char32_t> codepoints = decodeUtf8(text);
+        const float sizeScale = sizePixels / m_basePixelHeight;
+        float cursorX = 0.0f;
+        float cursorY = 0.0f;
+        float lowestBaseline = 0.0f;
+        float maximumLineWidth = 0.0f;
+        bool hasGeometry = false;
+
+        float minX = std::numeric_limits<float>::max();
+        float minY = std::numeric_limits<float>::max();
+        float maxX = std::numeric_limits<float>::lowest();
+        float maxY = std::numeric_limits<float>::lowest();
+
+        for (std::size_t index = 0; index < codepoints.size(); ++index) {
+            const char32_t codepoint = codepoints[index];
+            if (codepoint == U'\r') {
+                continue;
+            }
+            if (codepoint == U'\n') {
+                maximumLineWidth = std::max(maximumLineWidth, cursorX);
+                cursorX = 0.0f;
+                cursorY -= m_lineHeight * sizeScale;
+                lowestBaseline = std::min(lowestBaseline, cursorY);
+                continue;
+            }
+
+            const Glyph* glyph = findGlyph(codepoint);
+            if (!glyph) {
+                continue;
+            }
+
+            const float xPosition = cursorX + glyph->xOffset * sizeScale;
+            const float yPosition = cursorY - (glyph->yOffset + glyph->height) * sizeScale;
+            const float width = glyph->width * sizeScale;
+            const float height = glyph->height * sizeScale;
+
+            if (width > 0.0f && height > 0.0f) {
+                hasGeometry = true;
+                minX = std::min(minX, xPosition);
+                minY = std::min(minY, yPosition);
+                maxX = std::max(maxX, xPosition + width);
+                maxY = std::max(maxY, yPosition + height);
+            }
+
+            cursorX += glyph->advance * sizeScale;
+
+            if (index + 1 < codepoints.size() && m_fontInfo) {
+                const char32_t nextCodepoint = codepoints[index + 1];
+                if (nextCodepoint != U'\n' && nextCodepoint != U'\r') {
+                    const Glyph* nextGlyph = findGlyph(nextCodepoint);
+                    if (nextGlyph) {
+                        const int kerning = stbtt_GetGlyphKernAdvance(
+                            m_fontInfo.get(),
+                            glyph->glyphIndex,
+                            nextGlyph->glyphIndex);
+                        cursorX += static_cast<float>(kerning) * m_scale * sizeScale;
+                    }
+                }
+            }
+
+            maximumLineWidth = std::max(maximumLineWidth, cursorX);
+        }
+
+        maximumLineWidth = std::max(maximumLineWidth, cursorX);
+        const float metricsTop = m_ascent * sizeScale;
+        const float metricsBottom = lowestBaseline + m_descent * sizeScale;
+
+        if (!hasGeometry) {
+            minX = 0.0f;
+            maxX = maximumLineWidth;
+            minY = metricsBottom;
+            maxY = metricsTop;
+        } else {
+            minX = std::min(minX, 0.0f);
+            maxX = std::max(maxX, maximumLineWidth);
+            minY = std::min(minY, metricsBottom);
+            maxY = std::max(maxY, metricsTop);
+        }
+
+        return TextBounds{ minX, minY, maxX, maxY };
+    }
+
+    float TextRenderer::measureTextWidth(const std::string& text, float sizePixels) const {
+        const auto bounds = measureTextBounds(text, sizePixels);
+        return bounds ? bounds->width() : 0.0f;
     }
 
     void TextRenderer::cleanup() {
@@ -150,283 +455,57 @@ namespace WidgeCraft {
             glDeleteProgram(m_shader);
             m_shader = 0;
         }
+
         m_fontInfo.reset();
         m_glyphs.clear();
         m_atlasData.clear();
         m_fontBuffer.clear();
+        m_vertices.clear();
         m_fallbackGlyph = nullptr;
-        m_basePixelHeight = 0.0f;
     }
 
     void TextRenderer::moveFrom(TextRenderer&& other) noexcept {
+        m_glyphs = std::move(other.m_glyphs);
+        m_atlasData = std::move(other.m_atlasData);
+        m_fontBuffer = std::move(other.m_fontBuffer);
+        m_vertices = std::move(other.m_vertices);
+        m_atlasWidth = other.m_atlasWidth;
+        m_atlasHeight = other.m_atlasHeight;
         m_texture = other.m_texture;
         m_vao = other.m_vao;
         m_vbo = other.m_vbo;
         m_shader = other.m_shader;
         m_fontInfo = std::move(other.m_fontInfo);
-        m_fontBuffer = std::move(other.m_fontBuffer);
-        m_glyphs = std::move(other.m_glyphs);
-        m_atlasData = std::move(other.m_atlasData);
-        m_atlasWidth = other.m_atlasWidth;
-        m_atlasHeight = other.m_atlasHeight;
         m_scale = other.m_scale;
         m_ascent = other.m_ascent;
         m_descent = other.m_descent;
         m_lineHeight = other.m_lineHeight;
         m_basePixelHeight = other.m_basePixelHeight;
+        m_edgeValue = other.m_edgeValue;
+        m_softness = other.m_softness;
         m_screenWidth = other.m_screenWidth;
         m_screenHeight = other.m_screenHeight;
-        m_edgeValue = other.m_edgeValue;
-        m_smoothing = other.m_smoothing;
         m_uniformProjection = other.m_uniformProjection;
-        m_uniformTextColor = other.m_uniformTextColor;
         m_uniformEdgeValue = other.m_uniformEdgeValue;
-        m_uniformSmoothing = other.m_uniformSmoothing;
+        m_uniformSoftness = other.m_uniformSoftness;
         m_projection = other.m_projection;
-        m_fallbackGlyph = other.m_fallbackGlyph;
 
+        if (auto it = m_glyphs.find(U'\uFFFD'); it != m_glyphs.end()) {
+            m_fallbackGlyph = &it->second;
+        } else if (auto it = m_glyphs.find(U'?'); it != m_glyphs.end()) {
+            m_fallbackGlyph = &it->second;
+        }
+
+        other.m_atlasWidth = 0;
+        other.m_atlasHeight = 0;
         other.m_texture = 0;
         other.m_vao = 0;
         other.m_vbo = 0;
         other.m_shader = 0;
-        other.m_atlasWidth = 0;
-        other.m_atlasHeight = 0;
-        other.m_scale = 1.0f;
-        other.m_ascent = 0.0f;
-        other.m_descent = 0.0f;
-        other.m_lineHeight = 0.0f;
-        other.m_basePixelHeight = 0.0f;
-        other.m_screenWidth = 0;
-        other.m_screenHeight = 0;
-        other.m_edgeValue = 0.0f;
-        other.m_smoothing = 0.0f;
-        other.m_uniformProjection = -1;
-        other.m_uniformTextColor = -1;
-        other.m_uniformEdgeValue = -1;
-        other.m_uniformSmoothing = -1;
-        other.m_projection = {};
         other.m_fallbackGlyph = nullptr;
-    }
-
-    void TextRenderer::setScreenSize(int width, int height) {
-        m_screenWidth = width;
-        m_screenHeight = height;
-        updateProjection();
-    }
-
-    void TextRenderer::renderText(const std::string& text, float x, float y, float sizePixels, Color color) {
-        if (text.empty() || m_shader == 0 || m_texture == 0) {
-            return;
-        }
-
-        if (sizePixels <= 0.0f) {
-            sizePixels = m_basePixelHeight;
-        }
-
-        if (sizePixels <= 0.0f || m_basePixelHeight <= 0.0f) {
-            return;
-        }
-
-        const float sizeScale = sizePixels / m_basePixelHeight;
-
-        std::vector<float> vertices;
-        vertices.reserve(text.size() * 6 * 4);
-
-        float cursorX = x;
-        float cursorY = y;
-
-        glUseProgram(m_shader);
-        glUniformMatrix4fv(m_uniformProjection, 1, GL_FALSE, m_projection.data());
-        glUniform3f(m_uniformTextColor, color.r, color.g, color.b);
-        const float minimumWidth = m_smoothing / sizeScale;
-        glUniform1f(m_uniformSmoothing, minimumWidth);
-
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, m_texture);
-        glBindVertexArray(m_vao);
-
-        const size_t vertexStride = 4;
-
-        for (size_t i = 0; i < text.size(); ++i) {
-            const char c = text[i];
-            if (c == '\n') {
-                cursorX = x;
-                cursorY -= m_lineHeight * sizeScale;
-                continue;
-            }
-
-            const Glyph* glyph = nullptr;
-            if (auto it = m_glyphs.find(c); it != m_glyphs.end()) {
-                glyph = &it->second;
-            } else {
-                glyph = m_fallbackGlyph;
-            }
-
-            if (!glyph) {
-                continue;
-            }
-
-            float xPos = cursorX + glyph->xOffset * sizeScale;
-            // yOffset is downwards-positive in stb_truetype, so convert to OpenGL's y-up space.
-            float yPos = cursorY - (glyph->yOffset + glyph->height) * sizeScale;
-            float w = glyph->width * sizeScale;
-            float h = glyph->height * sizeScale;
-
-            if (w > 0.0f && h > 0.0f) {
-                vertices.insert(vertices.end(), {
-                    xPos,         yPos,         glyph->u0, glyph->v0,
-                    xPos + w,     yPos,         glyph->u1, glyph->v0,
-                    xPos + w,     yPos + h,     glyph->u1, glyph->v1,
-
-                    xPos,         yPos,         glyph->u0, glyph->v0,
-                    xPos + w,     yPos + h,     glyph->u1, glyph->v1,
-                    xPos,         yPos + h,     glyph->u0, glyph->v1,
-                });
-            }
-
-            cursorX += glyph->advance * sizeScale;
-
-            if (i + 1 < text.size() && m_fontInfo) {
-                const char nextChar = text[i + 1];
-                if (nextChar != '\n') {
-                    int nextGlyphIndex = 0;
-                    if (auto itNext = m_glyphs.find(nextChar); itNext != m_glyphs.end()) {
-                        nextGlyphIndex = itNext->second.glyphIndex;
-                    } else if (m_fallbackGlyph) {
-                        nextGlyphIndex = m_fallbackGlyph->glyphIndex;
-                    }
-                    if (glyph->glyphIndex >= 0 && nextGlyphIndex >= 0) {
-                        int kern = stbtt_GetGlyphKernAdvance(m_fontInfo.get(), glyph->glyphIndex, nextGlyphIndex);
-                        cursorX += static_cast<float>(kern) * m_scale * sizeScale;
-                    }
-                }
-            }
-        }
-
-        if (!vertices.empty()) {
-            glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-            glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertices.size() * sizeof(float)), vertices.data(), GL_DYNAMIC_DRAW);
-            glDrawArrays(GL_TRIANGLES, 0, static_cast<GLint>(vertices.size() / vertexStride));
-        }
-
-        glBindVertexArray(0);
-        glBindTexture(GL_TEXTURE_2D, 0);
-        glUseProgram(0);
-    }
-
-    std::optional<TextRenderer::TextBounds> TextRenderer::measureTextBounds(const std::string& text, float sizePixels) const {
-        if (text.empty() || m_basePixelHeight <= 0.0f) {
-            return std::nullopt;
-        }
-
-        if (sizePixels <= 0.0f) {
-            sizePixels = m_basePixelHeight;
-        }
-
-        if (sizePixels <= 0.0f) {
-            return std::nullopt;
-        }
-
-        const float sizeScale = sizePixels / m_basePixelHeight;
-
-        float cursorX = 0.0f;
-        float cursorY = 0.0f;
-        float lowestBaseline = 0.0f;
-        float maxLineWidth = 0.0f;
-        bool hasGeometry = false;
-
-        float minX = std::numeric_limits<float>::max();
-        float minY = std::numeric_limits<float>::max();
-        float maxX = std::numeric_limits<float>::lowest();
-        float maxY = std::numeric_limits<float>::lowest();
-
-        for (size_t i = 0; i < text.size(); ++i) {
-            const char c = text[i];
-            if (c == '\n') {
-                maxLineWidth = std::max(maxLineWidth, cursorX);
-                cursorX = 0.0f;
-                cursorY -= m_lineHeight * sizeScale;
-                lowestBaseline = std::min(lowestBaseline, cursorY);
-                continue;
-            }
-
-            const Glyph* glyph = nullptr;
-            if (auto it = m_glyphs.find(c); it != m_glyphs.end()) {
-                glyph = &it->second;
-            } else {
-                glyph = m_fallbackGlyph;
-            }
-
-            if (!glyph) {
-                continue;
-            }
-
-            const float xPos = cursorX + glyph->xOffset * sizeScale;
-            const float yPos = cursorY - (glyph->yOffset + glyph->height) * sizeScale;
-            const float w = glyph->width * sizeScale;
-            const float h = glyph->height * sizeScale;
-
-            if (w > 0.0f && h > 0.0f) {
-                hasGeometry = true;
-                minX = std::min(minX, xPos);
-                minY = std::min(minY, yPos);
-                maxX = std::max(maxX, xPos + w);
-                maxY = std::max(maxY, yPos + h);
-            }
-
-            cursorX += glyph->advance * sizeScale;
-            maxLineWidth = std::max(maxLineWidth, cursorX);
-
-            if (i + 1 < text.size()) {
-                const char nextChar = text[i + 1];
-                if (nextChar != '\n') {
-                    int nextGlyphIndex = 0;
-                    if (auto itNext = m_glyphs.find(nextChar); itNext != m_glyphs.end()) {
-                        nextGlyphIndex = itNext->second.glyphIndex;
-                    } else if (m_fallbackGlyph) {
-                        nextGlyphIndex = m_fallbackGlyph->glyphIndex;
-                    }
-
-                    if (glyph->glyphIndex >= 0 && nextGlyphIndex >= 0) {
-                        int kern = stbtt_GetGlyphKernAdvance(m_fontInfo.get(), glyph->glyphIndex, nextGlyphIndex);
-                        cursorX += static_cast<float>(kern) * m_scale * sizeScale;
-                        maxLineWidth = std::max(maxLineWidth, cursorX);
-                    }
-                }
-            }
-        }
-
-        maxLineWidth = std::max(maxLineWidth, cursorX);
-
-        if (!hasGeometry) {
-            if (maxLineWidth <= 0.0f) {
-                return std::nullopt;
-            }
-
-            minX = 0.0f;
-            maxX = maxLineWidth;
-        } else {
-            minX = std::min(minX, 0.0f);
-            maxX = std::max(maxX, maxLineWidth);
-        }
-
-        const float top = m_ascent * sizeScale;
-        const float bottom = lowestBaseline + m_descent * sizeScale;
-
-        if (!hasGeometry) {
-            minY = bottom;
-            maxY = top;
-        } else {
-            minY = std::min(minY, bottom);
-            maxY = std::max(maxY, top);
-        }
-
-        TextBounds bounds{};
-        bounds.minX = minX;
-        bounds.minY = minY;
-        bounds.maxX = maxX;
-        bounds.maxY = maxY;
-        return bounds;
+        other.m_uniformProjection = -1;
+        other.m_uniformEdgeValue = -1;
+        other.m_uniformSoftness = -1;
     }
 
     bool TextRenderer::loadFont(const std::string& fontPath) {
@@ -436,113 +515,110 @@ namespace WidgeCraft {
         }
 
         file.seekg(0, std::ios::end);
-        const std::streampos size = file.tellg();
-        if (size <= 0) {
+        const std::streampos fileSize = file.tellg();
+        if (fileSize <= 0) {
             return false;
         }
         file.seekg(0, std::ios::beg);
 
-        m_fontBuffer.resize(static_cast<size_t>(size));
-        file.read(reinterpret_cast<char*>(m_fontBuffer.data()), size);
+        m_fontBuffer.resize(static_cast<std::size_t>(fileSize));
+        file.read(reinterpret_cast<char*>(m_fontBuffer.data()), static_cast<std::streamsize>(fileSize));
         if (!file) {
             return false;
         }
 
-        if (!stbtt_InitFont(m_fontInfo.get(), m_fontBuffer.data(), 0)) {
-            return false;
-        }
-
-        return true;
+        return stbtt_InitFont(m_fontInfo.get(), m_fontBuffer.data(), 0) != 0;
     }
 
     void TextRenderer::buildAtlas(float pixelHeight) {
         if (!m_fontInfo) {
-            throw std::runtime_error("Font data not loaded");
+            throw std::runtime_error("Font data has not been loaded");
         }
 
+        pixelHeight = std::clamp(pixelHeight, 16.0f, 256.0f);
         m_glyphs.clear();
-        m_glyphs.reserve(static_cast<size_t>(kLastChar - kFirstChar + 1));
-
         m_atlasWidth = kAtlasSize;
         m_atlasHeight = kAtlasSize;
-        m_atlasData.assign(static_cast<size_t>(m_atlasWidth * m_atlasHeight), 0);
-
+        m_atlasData.assign(static_cast<std::size_t>(m_atlasWidth * m_atlasHeight), 0);
         m_scale = stbtt_ScaleForPixelHeight(m_fontInfo.get(), pixelHeight);
 
         int ascent = 0;
         int descent = 0;
         int lineGap = 0;
         stbtt_GetFontVMetrics(m_fontInfo.get(), &ascent, &descent, &lineGap);
-        m_ascent = ascent * m_scale;
-        m_descent = descent * m_scale;
-        m_lineHeight = (ascent - descent + lineGap) * m_scale;
+        m_ascent = static_cast<float>(ascent) * m_scale;
+        m_descent = static_cast<float>(descent) * m_scale;
+        m_lineHeight = static_cast<float>(ascent - descent + lineGap) * m_scale;
         m_basePixelHeight = m_ascent - m_descent;
+
+        const std::vector<char32_t> requestedCodepoints = defaultCodepoints();
+        std::unordered_set<char32_t> seen;
+        seen.reserve(requestedCodepoints.size());
+        m_glyphs.reserve(requestedCodepoints.size());
 
         int penX = kPadding;
         int penY = kPadding;
         int rowHeight = 0;
 
-        for (int codepoint = kFirstChar; codepoint <= kLastChar; ++codepoint) {
-            int glyphIndex = stbtt_FindGlyphIndex(m_fontInfo.get(), codepoint);
+        for (const char32_t codepoint : requestedCodepoints) {
+            if (!seen.insert(codepoint).second) {
+                continue;
+            }
+
+            const int glyphIndex = stbtt_FindGlyphIndex(m_fontInfo.get(), static_cast<int>(codepoint));
+            if (glyphIndex == 0 && codepoint != U'?') {
+                continue;
+            }
 
             int width = 0;
             int height = 0;
-            int xoff = 0;
-            int yoff = 0;
+            int xOffset = 0;
+            int yOffset = 0;
             unsigned char* sdf = nullptr;
 
-            const bool glyphHasContours = glyphIndex != 0 && stbtt_IsGlyphEmpty(m_fontInfo.get(), glyphIndex) == 0;
-
-            if (glyphHasContours) {
+            if (stbtt_IsGlyphEmpty(m_fontInfo.get(), glyphIndex) == 0) {
                 sdf = stbtt_GetGlyphSDF(
                     m_fontInfo.get(),
                     m_scale,
                     glyphIndex,
                     kPadding,
                     kOnEdgeValue,
-                    kPixelDistScale,
+                    kPixelDistanceScale,
                     &width,
                     &height,
-                    &xoff,
-                    &yoff);
-
-                if (!sdf) {
-                    width = 0;
-                    height = 0;
-                    xoff = 0;
-                    yoff = 0;
-                }
+                    &xOffset,
+                    &yOffset);
             }
 
-            if (width > 0 && height > 0 && sdf) {
+            if (sdf && width > 0 && height > 0) {
                 if (penX + width + kPadding > m_atlasWidth) {
                     penX = kPadding;
                     penY += rowHeight + kPadding;
                     rowHeight = 0;
                 }
-
                 if (penY + height + kPadding > m_atlasHeight) {
                     stbtt_FreeSDF(sdf, nullptr);
-                    throw std::runtime_error("Font atlas too small for requested glyphs");
+                    throw std::runtime_error("SDF font atlas is too small for the default character set");
                 }
 
                 for (int row = 0; row < height; ++row) {
-                    unsigned char* dest = m_atlasData.data() + (penY + row) * m_atlasWidth + penX;
-                    unsigned char* src = sdf + row * width;
-                    std::copy(src, src + width, dest);
+                    unsigned char* destination = m_atlasData.data()
+                        + static_cast<std::size_t>((penY + row) * m_atlasWidth + penX);
+                    const unsigned char* source = sdf + static_cast<std::size_t>(row * width);
+                    std::copy(source, source + width, destination);
                 }
-
                 rowHeight = std::max(rowHeight, height);
             }
 
             int advanceWidth = 0;
-            int leftBearing = 0;
-            stbtt_GetGlyphHMetrics(m_fontInfo.get(), glyphIndex, &advanceWidth, &leftBearing);
+            int leftSideBearing = 0;
+            stbtt_GetGlyphHMetrics(m_fontInfo.get(), glyphIndex, &advanceWidth, &leftSideBearing);
+            (void)leftSideBearing;
 
             Glyph glyph{};
-            glyph.advance = advanceWidth * m_scale;
-            glyph.xOffset = static_cast<float>(xoff);
-            glyph.yOffset = static_cast<float>(yoff);
+            glyph.advance = static_cast<float>(advanceWidth) * m_scale;
+            glyph.xOffset = static_cast<float>(xOffset);
+            glyph.yOffset = static_cast<float>(yOffset);
             glyph.width = static_cast<float>(width);
             glyph.height = static_cast<float>(height);
             glyph.u0 = width > 0 ? static_cast<float>(penX) / static_cast<float>(m_atlasWidth) : 0.0f;
@@ -550,120 +626,107 @@ namespace WidgeCraft {
             glyph.u1 = width > 0 ? static_cast<float>(penX + width) / static_cast<float>(m_atlasWidth) : 0.0f;
             glyph.v1 = height > 0 ? static_cast<float>(penY) / static_cast<float>(m_atlasHeight) : 0.0f;
             glyph.glyphIndex = glyphIndex;
-
-            m_glyphs.emplace(static_cast<char>(codepoint), glyph);
-
-            if (width > 0) {
-                penX += width + kPadding;
-            } else {
-                penX += static_cast<int>(glyph.advance) + kPadding;
-            }
+            m_glyphs.emplace(codepoint, glyph);
 
             if (sdf) {
+                penX += width + kPadding;
                 stbtt_FreeSDF(sdf, nullptr);
             }
         }
 
-        if (auto it = m_glyphs.find('?'); it != m_glyphs.end()) {
+        if (auto it = m_glyphs.find(U'\uFFFD'); it != m_glyphs.end()) {
+            m_fallbackGlyph = &it->second;
+        } else if (auto it = m_glyphs.find(U'?'); it != m_glyphs.end()) {
             m_fallbackGlyph = &it->second;
         } else if (!m_glyphs.empty()) {
             m_fallbackGlyph = &m_glyphs.begin()->second;
-        } else {
-            m_fallbackGlyph = nullptr;
         }
 
         m_edgeValue = static_cast<float>(kOnEdgeValue) / 255.0f;
-        m_smoothing = 0.5f / kPixelDistScale;
+        m_softness = 1.0f;
     }
 
     void TextRenderer::createShader() {
-        GLuint vertexShader = compileShader(GL_VERTEX_SHADER, kVertexShaderSrc);
-        GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, kFragmentShaderSrc);
+        const GLuint vertexShader = compileShader(GL_VERTEX_SHADER, kVertexShader);
+        const GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, kFragmentShader);
         m_shader = linkProgram(vertexShader, fragmentShader);
         glDeleteShader(vertexShader);
         glDeleteShader(fragmentShader);
 
         glUseProgram(m_shader);
-        GLint textureLocation = glGetUniformLocation(m_shader, "uTexture");
-        glUniform1i(textureLocation, 0);
+        glUniform1i(glGetUniformLocation(m_shader, "uTexture"), 0);
         m_uniformProjection = glGetUniformLocation(m_shader, "uProjection");
-        m_uniformTextColor = glGetUniformLocation(m_shader, "uTextColor");
         m_uniformEdgeValue = glGetUniformLocation(m_shader, "uEdgeValue");
-        m_uniformSmoothing = glGetUniformLocation(m_shader, "uSmoothing");
-        glUniform1f(m_uniformEdgeValue, m_edgeValue);
-        glUniform1f(m_uniformSmoothing, m_smoothing);
+        m_uniformSoftness = glGetUniformLocation(m_shader, "uSoftness");
         glUseProgram(0);
     }
 
     void TextRenderer::createBuffers() {
         glGenVertexArrays(1, &m_vao);
-        glBindVertexArray(m_vao);
-
         glGenBuffers(1, &m_vbo);
+
+        glBindVertexArray(m_vao);
         glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
-        glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(sizeof(float) * 6 * 4), nullptr, GL_DYNAMIC_DRAW);
+        glBufferData(GL_ARRAY_BUFFER, 0, nullptr, GL_DYNAMIC_DRAW);
 
         glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), reinterpret_cast<void*>(0));
+        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), reinterpret_cast<void*>(offsetof(Vertex, x)));
         glEnableVertexAttribArray(1);
-        glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), reinterpret_cast<void*>(2 * sizeof(float)));
+        glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), reinterpret_cast<void*>(offsetof(Vertex, u)));
+        glEnableVertexAttribArray(2);
+        glVertexAttribPointer(2, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), reinterpret_cast<void*>(offsetof(Vertex, r)));
 
-        glBindVertexArray(0);
         glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glBindVertexArray(0);
     }
 
     void TextRenderer::uploadAtlasTexture() {
         if (m_atlasData.empty()) {
-            throw std::runtime_error("Atlas data is empty");
+            throw std::runtime_error("SDF atlas data is empty");
         }
 
         glGenTextures(1, &m_texture);
         glBindTexture(GL_TEXTURE_2D, m_texture);
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, m_atlasWidth, m_atlasHeight, 0, GL_RED, GL_UNSIGNED_BYTE, m_atlasData.data());
+        glTexImage2D(
+            GL_TEXTURE_2D,
+            0,
+            GL_R8,
+            m_atlasWidth,
+            m_atlasHeight,
+            0,
+            GL_RED,
+            GL_UNSIGNED_BYTE,
+            m_atlasData.data());
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glGenerateMipmap(GL_TEXTURE_2D);
         glBindTexture(GL_TEXTURE_2D, 0);
     }
 
     void TextRenderer::updateProjection() {
-        const float left = 0.0f;
-        const float right = static_cast<float>(m_screenWidth);
-        const float bottom = 0.0f;
-        const float top = static_cast<float>(m_screenHeight);
-        const float nearPlane = -1.0f;
-        const float farPlane = 1.0f;
-
-        const float rl = right - left;
-        const float tb = top - bottom;
-        const float fn = farPlane - nearPlane;
-
-        if (rl == 0.0f || tb == 0.0f || fn == 0.0f) {
-            m_projection = {
-                1.0f, 0.0f, 0.0f, 0.0f,
-                0.0f, 1.0f, 0.0f, 0.0f,
-                0.0f, 0.0f, 1.0f, 0.0f,
-                0.0f, 0.0f, 0.0f, 1.0f
-            };
-        } else {
-            m_projection = {
-                2.0f / rl, 0.0f,       0.0f,        0.0f,
-                0.0f,      2.0f / tb,  0.0f,        0.0f,
-                0.0f,      0.0f,      -2.0f / fn,   0.0f,
-                -(right + left) / rl,
-                -(top + bottom) / tb,
-                -(farPlane + nearPlane) / fn,
-                1.0f
-            };
+        const float width = static_cast<float>(m_screenWidth);
+        const float height = static_cast<float>(m_screenHeight);
+        if (width <= 0.0f || height <= 0.0f) {
+            m_projection = Mat4::identity();
+            return;
         }
 
-        if (m_shader != 0) {
-            glUseProgram(m_shader);
-            glUniformMatrix4fv(m_uniformProjection, 1, GL_FALSE, m_projection.data());
-            glUseProgram(0);
+        m_projection = Mat4::identity();
+        m_projection(0, 0) = 2.0f / width;
+        m_projection(1, 1) = 2.0f / height;
+        m_projection(2, 2) = -1.0f;
+        m_projection(0, 3) = -1.0f;
+        m_projection(1, 3) = -1.0f;
+    }
+
+    const TextRenderer::Glyph* TextRenderer::findGlyph(char32_t codepoint) const {
+        if (const auto it = m_glyphs.find(codepoint); it != m_glyphs.end()) {
+            return &it->second;
         }
+        return m_fallbackGlyph;
     }
 
 } // namespace WidgeCraft

--- a/src/WidgeCraft.cpp
+++ b/src/WidgeCraft.cpp
@@ -1,23 +1,29 @@
 #include "WidgeCraft/WidgeCraft.hpp"
 
-#include "WidgeCraft/ShapeRenderer.hpp"
-#include "WidgeCraft/TextRenderer.hpp"
-
-// Order matters: glad before glfw
+// GLAD must be included before GLFW.
 #include <glad/glad.h>
-#include <GLFW/glfw3.h>
 
+#include <algorithm>
+#include <chrono>
 #include <filesystem>
+#include <thread>
 #include <utility>
 
 namespace WidgeCraft {
 
     namespace {
         std::string resolveDefaultFontPath() {
-            const std::filesystem::path defaultPath = std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "fonts/Roboto-Regular.ttf";
-            return defaultPath.string();
+            const std::filesystem::path configuredPath =
+                std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "fonts/Roboto-Regular.ttf";
+            if (std::filesystem::exists(configuredPath)) {
+                return configuredPath.string();
+            }
+
+            const std::filesystem::path localPath =
+                std::filesystem::current_path() / "assets/fonts/Roboto-Regular.ttf";
+            return localPath.string();
         }
-    }
+    } // namespace
 
     WidgeCraft::WidgeCraft(std::string title, int width, int height, std::string fontPath, float fontPixelHeight)
         : m_window(width, height, std::move(title))
@@ -26,19 +32,42 @@ namespace WidgeCraft {
         initializeGraphics();
     }
 
-    void WidgeCraft::Run() {
+    void WidgeCraft::Run(int targetFramesPerSecond) {
+        using Clock = std::chrono::steady_clock;
+        using Seconds = std::chrono::duration<double>;
+
+        m_targetFrameRate = std::max(0, targetFramesPerSecond);
+        auto previousFrame = Clock::now();
+
         while (!m_window.shouldClose()) {
+            const auto frameStart = Clock::now();
+            m_deltaTime = static_cast<float>(std::min(0.25, Seconds(frameStart - previousFrame).count()));
+            previousFrame = frameStart;
+            m_elapsedTime += static_cast<double>(m_deltaTime);
+
+            m_window.pollEvents();
             Update();
             Render();
+            m_window.swapBuffers();
 
-            glfwSwapBuffers(m_window.getNativeHandle());
-            m_window.pollEvents();
+            if (m_targetFrameRate > 0 && !m_window.isVSyncEnabled()) {
+                const Seconds targetDuration(1.0 / static_cast<double>(m_targetFrameRate));
+                while (Clock::now() - frameStart < targetDuration) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+            }
         }
+    }
+
+    void WidgeCraft::Stop() {
+        m_window.requestClose();
     }
 
     void WidgeCraft::Update() {
         m_textRenderer.setScreenSize(m_window.getWidth(), m_window.getHeight());
-        m_shapeRenderer.setScreenSize(static_cast<float>(m_window.getWidth()), static_cast<float>(m_window.getHeight()));
+        m_shapeRenderer.setScreenSize(
+            static_cast<float>(m_window.getWidth()),
+            static_cast<float>(m_window.getHeight()));
 
         if (m_updateCallback) {
             m_updateCallback(*this);
@@ -47,27 +76,31 @@ namespace WidgeCraft {
 
     void WidgeCraft::Render() {
         glClearColor(m_clearColor.r, m_clearColor.g, m_clearColor.b, m_clearColor.a);
-        glClear(GL_COLOR_BUFFER_BIT);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+        m_shapeRenderer.beginFrame();
+        m_textRenderer.beginFrame();
 
         if (m_renderCallback) {
             m_renderCallback(*this);
         }
 
-        m_window.getRootFrame().render(m_textRenderer, m_shapeRenderer);
+        m_shapeRenderer.flush();
+        m_textRenderer.flush();
+        m_window.getRootFrame().render(m_textRenderer, m_shapeRenderer, m_window.getInput());
+        m_shapeRenderer.flush();
+        m_textRenderer.flush();
     }
 
     void WidgeCraft::initializeGraphics() {
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glDisable(GL_CULL_FACE);
+        glDisable(GL_DEPTH_TEST);
     }
 
     std::string WidgeCraft::resolveFontPath(const std::string& fontPath) {
-        if (!fontPath.empty()) {
-            return fontPath;
-        }
-
-        return resolveDefaultFontPath();
+        return fontPath.empty() ? resolveDefaultFontPath() : fontPath;
     }
 
 } // namespace WidgeCraft
-

--- a/src/Widget.cpp
+++ b/src/Widget.cpp
@@ -2,29 +2,43 @@
 
 #include "WidgeCraft/Frame.hpp"
 #include "WidgeCraft/ShapeRenderer.hpp"
-#include "WidgeCraft/TextRenderer.hpp"
 
 #include <algorithm>
 #include <utility>
 
 namespace WidgeCraft {
 
+    namespace {
+        float defaultUiTextSize(const TextRenderer& textRenderer) {
+            return std::max(14.0f, textRenderer.getBasePixelHeight() * 0.375f);
+        }
+
+        float alignmentOffset(HorizontalAlignment alignment, float availableWidth) {
+            switch (alignment) {
+            case HorizontalAlignment::Center:
+                return availableWidth * 0.5f;
+            case HorizontalAlignment::Right:
+                return availableWidth;
+            case HorizontalAlignment::Left:
+            default:
+                return 0.0f;
+            }
+        }
+    } // namespace
+
     Widget::Widget(std::string name)
         : m_name(std::move(name)) {
-    }
-
-    void Widget::setVisible(bool visible) {
-        m_visible = visible;
+        if (m_name.empty()) {
+            throw std::invalid_argument("Widget names cannot be empty");
+        }
     }
 
     void Widget::setPosition(float x, float y) {
-        m_position.x = x;
-        m_position.y = y;
+        m_position = { x, y };
     }
 
     void Widget::setSize(float width, float height) {
-        m_size.x = width;
-        m_size.y = height;
+        m_size = { std::max(0.0f, width), std::max(0.0f, height) };
         m_hasExplicitSize = true;
     }
 
@@ -33,142 +47,260 @@ namespace WidgeCraft {
     }
 
     void Widget::setComputedSize(float width, float height) {
-        m_size.x = width;
-        m_size.y = height;
+        m_size = { std::max(0.0f, width), std::max(0.0f, height) };
+    }
+
+    Rect Widget::resolveRect(const Frame& frame, const Size& desiredSize) const {
+        const Rect parentRect = frame.getAbsoluteRect();
+        Size size = desiredSize;
+        if (m_hasExplicitSize) {
+            if (m_size.x > 0.0f) {
+                size.x = m_size.x;
+            }
+            if (m_size.y > 0.0f) {
+                size.y = m_size.y;
+            }
+        }
+
+        Rect result{ parentRect.x, parentRect.y, std::max(0.0f, size.x), std::max(0.0f, size.y) };
+        switch (m_anchor) {
+        case Anchor::TopLeft:
+            result.x += m_position.x;
+            result.y += parentRect.height - m_position.y - result.height;
+            break;
+        case Anchor::TopCenter:
+            result.x += (parentRect.width - result.width) * 0.5f + m_position.x;
+            result.y += parentRect.height - m_position.y - result.height;
+            break;
+        case Anchor::TopRight:
+            result.x += parentRect.width - m_position.x - result.width;
+            result.y += parentRect.height - m_position.y - result.height;
+            break;
+        case Anchor::CenterLeft:
+            result.x += m_position.x;
+            result.y += (parentRect.height - result.height) * 0.5f + m_position.y;
+            break;
+        case Anchor::Center:
+            result.x += (parentRect.width - result.width) * 0.5f + m_position.x;
+            result.y += (parentRect.height - result.height) * 0.5f + m_position.y;
+            break;
+        case Anchor::CenterRight:
+            result.x += parentRect.width - m_position.x - result.width;
+            result.y += (parentRect.height - result.height) * 0.5f + m_position.y;
+            break;
+        case Anchor::BottomLeft:
+            result.x += m_position.x;
+            result.y += m_position.y;
+            break;
+        case Anchor::BottomCenter:
+            result.x += (parentRect.width - result.width) * 0.5f + m_position.x;
+            result.y += m_position.y;
+            break;
+        case Anchor::BottomRight:
+            result.x += parentRect.width - m_position.x - result.width;
+            result.y += m_position.y;
+            break;
+        }
+        return result;
+    }
+
+    Rect Widget::getAbsoluteRect() const {
+        if (!m_parent) {
+            return { m_position.x, m_position.y, m_size.x, m_size.y };
+        }
+        return resolveRect(*m_parent, m_size);
     }
 
     Widgets::Widgets(Frame& owner)
         : m_owner(owner) {
     }
 
+    Widget* Widgets::find(const std::string& name) {
+        const auto iterator = std::find_if(m_widgets.begin(), m_widgets.end(), [&](const auto& widget) {
+            return widget && widget->getName() == name;
+        });
+        return iterator != m_widgets.end() ? iterator->get() : nullptr;
+    }
+
+    const Widget* Widgets::find(const std::string& name) const {
+        const auto iterator = std::find_if(m_widgets.begin(), m_widgets.end(), [&](const auto& widget) {
+            return widget && widget->getName() == name;
+        });
+        return iterator != m_widgets.end() ? iterator->get() : nullptr;
+    }
+
+    bool Widgets::remove(const std::string& name) {
+        const auto iterator = std::find_if(m_widgets.begin(), m_widgets.end(), [&](const auto& widget) {
+            return widget && widget->getName() == name;
+        });
+        if (iterator == m_widgets.end()) {
+            return false;
+        }
+        m_widgets.erase(iterator);
+        return true;
+    }
+
     Label::Label(std::string name, std::string text)
-        : Widget(std::move(name)), m_text(std::move(text)) {
+        : Widget(std::move(name))
+        , m_text(std::move(text)) {
     }
 
-    void Label::setText(std::string text) {
-        m_text = std::move(text);
-    }
+    void Label::render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer, const Input& input) {
+        (void)shapeRenderer;
+        (void)input;
 
-    void Label::render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) {
-        float size = m_textSizePixels;
-        if (size <= 0.0f) {
-            size = textRenderer.getBasePixelHeight();
+        const float textSize = m_textSizePixels > 0.0f ? m_textSizePixels : defaultUiTextSize(textRenderer);
+        const auto bounds = textRenderer.measureTextBounds(m_text, textSize);
+        const Size desiredSize = bounds ? Size{ bounds->width(), bounds->height() } : Size{};
+        const Rect rect = resolveRect(frame, desiredSize);
+        setComputedSize(rect.width, rect.height);
+
+        if (!bounds || m_text.empty()) {
+            return;
         }
 
-        const Position position = getPosition();
-        float offsetX = 0.0f;
-        float offsetY = 0.0f;
-        float boundsWidth = 0.0f;
-        float boundsHeight = 0.0f;
-        bool haveBounds = false;
-
-        if (!m_text.empty()) {
-            if (auto bounds = textRenderer.measureTextBounds(m_text, size)) {
-                boundsWidth = bounds->maxX - bounds->minX;
-                boundsHeight = bounds->maxY - bounds->minY;
-                offsetX = bounds->minX;
-                offsetY = bounds->minY;
-                haveBounds = true;
-            }
-        }
-
-        float finalWidth = boundsWidth;
-        float finalHeight = boundsHeight;
-
-        if (hasExplicitSize()) {
-            const Size explicitSize = getSize();
-            if (explicitSize.x > 0.0f) {
-                finalWidth = std::max(finalWidth, explicitSize.x);
-            }
-            if (explicitSize.y > 0.0f) {
-                finalHeight = std::max(finalHeight, explicitSize.y);
-            }
-        } else {
-            if (finalWidth <= 0.0f) {
-                finalWidth = size;
-            }
-            if (finalHeight <= 0.0f) {
-                finalHeight = size;
-            }
-        }
-
-        const Position framePosition = frame.getAbsolutePosition();
-        const float borderX = framePosition.x + position.x + (haveBounds ? offsetX : 0.0f);
-        const float borderY = framePosition.y + position.y + (haveBounds ? offsetY : 0.0f);
-        shapeRenderer.drawRectOutline(borderX, borderY, finalWidth, finalHeight, 1.0f, Colors::Black);
-        setComputedSize(finalWidth, finalHeight);
-
-        if (!m_text.empty()) {
-            frame.getTextBatch().addText(m_text, position.x, position.y, size, m_color);
-        }
+        const float availableWidth = std::max(0.0f, rect.width - bounds->width());
+        const float baselineX = rect.x - bounds->minX + alignmentOffset(m_alignment, availableWidth);
+        const float baselineY = rect.y + (rect.height - bounds->height()) * 0.5f - bounds->minY;
+        textRenderer.renderText(m_text, baselineX, baselineY, textSize, m_color);
     }
 
     Button::Button(std::string name, std::string text)
-        : Widget(std::move(name)), m_text(std::move(text)) {
+        : Widget(std::move(name))
+        , m_text(std::move(text)) {
     }
 
-    void Button::setText(std::string text) {
-        m_text = std::move(text);
+    void Button::setPadding(float horizontal, float vertical) {
+        m_horizontalPadding = std::max(0.0f, horizontal);
+        m_verticalPadding = std::max(0.0f, vertical);
     }
 
-    void Button::render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer) {
-        float size = m_textSizePixels;
-        if (size <= 0.0f) {
-            size = textRenderer.getBasePixelHeight();
-        }
+    void Button::render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer, const Input& input) {
+        const float textSize = m_textSizePixels > 0.0f ? m_textSizePixels : defaultUiTextSize(textRenderer);
+        const auto bounds = textRenderer.measureTextBounds(m_text, textSize);
+        const float textWidth = bounds ? bounds->width() : 0.0f;
+        const float textHeight = bounds ? bounds->height() : textSize;
+        const Size desiredSize{
+            textWidth + m_horizontalPadding * 2.0f,
+            textHeight + m_verticalPadding * 2.0f
+        };
+        const Rect rect = resolveRect(frame, desiredSize);
+        setComputedSize(rect.width, rect.height);
 
-        const Position position = getPosition();
-        float offsetX = 0.0f;
-        float offsetY = 0.0f;
-        float boundsWidth = 0.0f;
-        float boundsHeight = 0.0f;
-        bool haveBounds = false;
-
-        if (!m_text.empty()) {
-            if (auto bounds = textRenderer.measureTextBounds(m_text, size)) {
-                boundsWidth = bounds->maxX - bounds->minX;
-                boundsHeight = bounds->maxY - bounds->minY;
-                offsetX = bounds->minX;
-                offsetY = bounds->minY;
-                haveBounds = true;
-            }
-        }
-
-        float finalWidth = boundsWidth;
-        float finalHeight = boundsHeight;
-
-        if (hasExplicitSize()) {
-            const Size explicitSize = getSize();
-            if (explicitSize.x > 0.0f) {
-                finalWidth = std::max(finalWidth, explicitSize.x);
-            }
-            if (explicitSize.y > 0.0f) {
-                finalHeight = std::max(finalHeight, explicitSize.y);
-            }
+        m_hovered = isEnabled() && rect.contains(input.mousePosition());
+        if (!isEnabled()) {
+            m_armed = false;
+            m_pressed = false;
         } else {
-            if (finalWidth <= 0.0f) {
-                finalWidth = size;
+            if (input.mousePressed(MouseButton::Left)) {
+                m_armed = m_hovered;
             }
-            if (finalHeight <= 0.0f) {
-                finalHeight = size;
+            m_pressed = m_armed && input.mouseDown(MouseButton::Left);
+
+            if (input.mouseReleased(MouseButton::Left)) {
+                const bool activate = m_armed && m_hovered;
+                m_armed = false;
+                m_pressed = false;
+                if (activate && m_onClick) {
+                    m_onClick();
+                }
             }
         }
 
-        const Position framePosition = frame.getAbsolutePosition();
-        const float rectX = framePosition.x + position.x + (haveBounds ? offsetX : 0.0f);
-        const float rectY = framePosition.y + position.y + (haveBounds ? offsetY : 0.0f);
+        Color background = m_backgroundColor;
+        if (!isEnabled()) {
+            background = m_disabledColor;
+        } else if (m_pressed) {
+            background = m_pressedColor;
+        } else if (m_hovered) {
+            background = m_hoverColor;
+        }
 
         if (m_showBackground) {
-            shapeRenderer.drawFilledRect(rectX, rectY, finalWidth, finalHeight, m_backgroundColor);
+            shapeRenderer.drawFilledRect(rect.x, rect.y, rect.width, rect.height, background);
+        }
+        if (m_showBorder) {
+            shapeRenderer.drawRectOutline(rect.x, rect.y, rect.width, rect.height, 1.0f, m_borderColor);
         }
 
-        shapeRenderer.drawRectOutline(rectX, rectY, finalWidth, finalHeight, 1.0f, Colors::Black);
-        setComputedSize(finalWidth, finalHeight);
+        if (bounds && !m_text.empty()) {
+            const float baselineX = rect.x + (rect.width - bounds->width()) * 0.5f - bounds->minX;
+            const float baselineY = rect.y + (rect.height - bounds->height()) * 0.5f - bounds->minY;
+            Color textColor = m_textColor;
+            if (!isEnabled()) {
+                textColor.a *= 0.55f;
+            }
+            textRenderer.renderText(m_text, baselineX, baselineY, textSize, textColor);
+        }
+    }
 
-        if (!m_text.empty()) {
-            frame.getTextBatch().addText(m_text, position.x, position.y, size, m_textColor);
+    Checkbox::Checkbox(std::string name, std::string text, bool checked)
+        : Widget(std::move(name))
+        , m_text(std::move(text))
+        , m_checked(checked) {
+    }
+
+    void Checkbox::render(Frame& frame, TextRenderer& textRenderer, ShapeRenderer& shapeRenderer, const Input& input) {
+        const float textSize = m_textSizePixels > 0.0f ? m_textSizePixels : defaultUiTextSize(textRenderer);
+        const auto bounds = textRenderer.measureTextBounds(m_text, textSize);
+        const float textWidth = bounds ? bounds->width() : 0.0f;
+        const float textHeight = bounds ? bounds->height() : textSize;
+        const float boxSize = std::max(16.0f, textHeight);
+        const float spacing = m_text.empty() ? 0.0f : 8.0f;
+        const Rect rect = resolveRect(frame, { boxSize + spacing + textWidth, std::max(boxSize, textHeight) });
+        setComputedSize(rect.width, rect.height);
+
+        const bool hovered = isEnabled() && rect.contains(input.mousePosition());
+        if (!isEnabled()) {
+            m_armed = false;
+        } else {
+            if (input.mousePressed(MouseButton::Left)) {
+                m_armed = hovered;
+            }
+            if (input.mouseReleased(MouseButton::Left)) {
+                const bool activate = m_armed && hovered;
+                m_armed = false;
+                if (activate) {
+                    m_checked = !m_checked;
+                    if (m_onChanged) {
+                        m_onChanged(m_checked);
+                    }
+                }
+            }
+        }
+
+        const float boxY = rect.y + (rect.height - boxSize) * 0.5f;
+        const Color boxColor = hovered ? Color{ 0.25f, 0.31f, 0.40f, 1.0f } : Color{ 0.15f, 0.18f, 0.23f, 1.0f };
+        shapeRenderer.drawFilledRect(rect.x, boxY, boxSize, boxSize, boxColor);
+        shapeRenderer.drawRectOutline(rect.x, boxY, boxSize, boxSize, 1.0f, Color{ 0.55f, 0.65f, 0.78f, 1.0f });
+
+        if (m_checked) {
+            const float thickness = std::max(2.0f, boxSize * 0.12f);
+            shapeRenderer.drawLine(
+                rect.x + boxSize * 0.22f,
+                boxY + boxSize * 0.52f,
+                rect.x + boxSize * 0.43f,
+                boxY + boxSize * 0.28f,
+                thickness,
+                Color{ 0.45f, 0.85f, 1.0f, 1.0f });
+            shapeRenderer.drawLine(
+                rect.x + boxSize * 0.43f,
+                boxY + boxSize * 0.28f,
+                rect.x + boxSize * 0.80f,
+                boxY + boxSize * 0.76f,
+                thickness,
+                Color{ 0.45f, 0.85f, 1.0f, 1.0f });
+        }
+
+        if (bounds && !m_text.empty()) {
+            const float textX = rect.x + boxSize + spacing - bounds->minX;
+            const float textY = rect.y + (rect.height - bounds->height()) * 0.5f - bounds->minY;
+            Color textColor = Colors::White;
+            if (!isEnabled()) {
+                textColor.a = 0.5f;
+            }
+            textRenderer.renderText(m_text, textX, textY, textSize, textColor);
         }
     }
 
 } // namespace WidgeCraft
-

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1,27 +1,33 @@
 #include "WidgeCraft/Window.hpp"
 
-// Order matters: glad before glfw
+// GLAD must be included before GLFW.
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <stdexcept>
-#include <iostream>
 
 namespace WidgeCraft {
 
     Window::Window(int width, int height, const std::string& title)
-        : m_window(nullptr)
-        , m_width(width)
+        : m_width(width)
         , m_height(height)
         , m_rootFrame("Window Frame") {
+
+        if (width <= 0 || height <= 0) {
+            throw std::invalid_argument("Window dimensions must be positive");
+        }
+
         if (!glfwInit()) {
             throw std::runtime_error("Failed to initialize GLFW");
         }
 
-        // Ask for OpenGL 3.3 core
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+        glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_TRUE);
+#ifdef _DEBUG
+        glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
+#endif
 
         m_window = glfwCreateWindow(width, height, title.c_str(), nullptr, nullptr);
         if (!m_window) {
@@ -32,38 +38,75 @@ namespace WidgeCraft {
         glfwMakeContextCurrent(m_window);
         glfwSetWindowUserPointer(m_window, this);
         glfwSetFramebufferSizeCallback(m_window, Window::framebufferSizeCallback);
+        glfwSetKeyCallback(m_window, Window::keyCallback);
+        glfwSetMouseButtonCallback(m_window, Window::mouseButtonCallback);
+        glfwSetCursorPosCallback(m_window, Window::cursorPositionCallback);
+        glfwSetScrollCallback(m_window, Window::scrollCallback);
 
-        // Load OpenGL function pointers via GLAD
-        if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+        if (!gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress))) {
+            glfwDestroyWindow(m_window);
+            m_window = nullptr;
+            glfwTerminate();
             throw std::runtime_error("Failed to initialize GLAD");
         }
 
-        glViewport(0, 0, width, height);
+        int framebufferWidth = width;
+        int framebufferHeight = height;
+        glfwGetFramebufferSize(m_window, &framebufferWidth, &framebufferHeight);
+        updateSize(framebufferWidth, framebufferHeight);
+        glViewport(0, 0, framebufferWidth, framebufferHeight);
+        setVSync(true);
 
         m_rootFrame.setDeletable(false);
-        m_rootFrame.setAnchor(Anchor::TopLeft);
-        m_rootFrame.setBackgroundColor(Colors::DarkGrey);
+        m_rootFrame.setAnchor(Anchor::BottomLeft);
+        m_rootFrame.setBackgroundVisible(false);
         m_rootFrame.setBorderVisible(false);
-        m_rootFrame.setBackgroundVisible(true);
         m_rootFrame.setPosition(0.0f, 0.0f);
-        m_rootFrame.setSize(static_cast<float>(width), static_cast<float>(height));
-
-        std::cout << "Window created: " << title << " (" << width << "x" << height << ")\n";
+        m_rootFrame.setSize(static_cast<float>(framebufferWidth), static_cast<float>(framebufferHeight));
     }
 
     Window::~Window() {
         if (m_window) {
             glfwDestroyWindow(m_window);
-            glfwTerminate();
+            m_window = nullptr;
         }
+        glfwTerminate();
     }
 
     bool Window::shouldClose() const {
-        return glfwWindowShouldClose(m_window);
+        return m_window == nullptr || glfwWindowShouldClose(m_window) != 0;
     }
 
-    void Window::pollEvents() const {
+    void Window::requestClose() {
+        if (m_window) {
+            glfwSetWindowShouldClose(m_window, GLFW_TRUE);
+        }
+    }
+
+    void Window::pollEvents() {
+        m_input.beginFrame();
         glfwPollEvents();
+    }
+
+    void Window::swapBuffers() const {
+        if (m_window) {
+            glfwSwapBuffers(m_window);
+        }
+    }
+
+    void Window::setVSync(bool enabled) {
+        m_vsyncEnabled = enabled;
+        glfwSwapInterval(enabled ? 1 : 0);
+    }
+
+    void Window::setTitle(const std::string& title) {
+        if (m_window) {
+            glfwSetWindowTitle(m_window, title.c_str());
+        }
+    }
+
+    float Window::getAspectRatio() const {
+        return m_height > 0 ? static_cast<float>(m_width) / static_cast<float>(m_height) : 1.0f;
     }
 
     void Window::updateSize(int width, int height) {
@@ -76,6 +119,49 @@ namespace WidgeCraft {
         if (auto* self = static_cast<Window*>(glfwGetWindowUserPointer(window))) {
             self->updateSize(width, height);
             glViewport(0, 0, width, height);
+        }
+    }
+
+    void Window::keyCallback(GLFWwindow* window, int key, int scanCode, int action, int modifiers) {
+        (void)scanCode;
+        (void)modifiers;
+        if (auto* self = static_cast<Window*>(glfwGetWindowUserPointer(window))) {
+            if (action == GLFW_PRESS || action == GLFW_REPEAT) {
+                self->m_input.setKey(key, true);
+            } else if (action == GLFW_RELEASE) {
+                self->m_input.setKey(key, false);
+            }
+        }
+    }
+
+    void Window::mouseButtonCallback(GLFWwindow* window, int button, int action, int modifiers) {
+        (void)modifiers;
+        if (auto* self = static_cast<Window*>(glfwGetWindowUserPointer(window))) {
+            if (action == GLFW_PRESS) {
+                self->m_input.setMouseButton(button, true);
+            } else if (action == GLFW_RELEASE) {
+                self->m_input.setMouseButton(button, false);
+            }
+        }
+    }
+
+    void Window::cursorPositionCallback(GLFWwindow* window, double x, double y) {
+        if (auto* self = static_cast<Window*>(glfwGetWindowUserPointer(window))) {
+            int windowWidth = 1;
+            int windowHeight = 1;
+            glfwGetWindowSize(window, &windowWidth, &windowHeight);
+
+            const float scaleX = windowWidth > 0 ? static_cast<float>(self->m_width) / static_cast<float>(windowWidth) : 1.0f;
+            const float scaleY = windowHeight > 0 ? static_cast<float>(self->m_height) / static_cast<float>(windowHeight) : 1.0f;
+            self->m_input.setMousePosition(
+                static_cast<float>(x) * scaleX,
+                static_cast<float>(self->m_height) - static_cast<float>(y) * scaleY);
+        }
+    }
+
+    void Window::scrollCallback(GLFWwindow* window, double xOffset, double yOffset) {
+        if (auto* self = static_cast<Window*>(glfwGetWindowUserPointer(window))) {
+            self->m_input.addScroll(static_cast<float>(xOffset), static_cast<float>(yOffset));
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,55 +1,120 @@
 #include "WidgeCraft/WidgeCraft.hpp"
 #include "WidgeCraft/Widget.hpp"
 
+#include <cmath>
 #include <iostream>
+#include <string>
 
-int main(int argc, char* argv[]) {
-    (void)argc;
-    (void)argv;
-
+int main() {
     try {
-        WidgeCraft::WidgeCraft wc("WidgeCraft Engine", 800, 600);
+        WidgeCraft::WidgeCraft app("WidgeCraft Engine", 1100, 720);
+        app.setClearColor({ 0.035f, 0.045f, 0.065f, 1.0f });
 
-        WidgeCraft::Frame& rootFrame = wc.getRootFrame();
-        rootFrame.setBorderVisible(false);
+        auto& root = app.getRootFrame();
+        root.setBackgroundVisible(false);
 
-        WidgeCraft::Frame& headerFrame = rootFrame.createChildFrame("Header");
-        headerFrame.setBackgroundVisible(false);
-        headerFrame.setBorderVisible(false);
+        auto& panel = root.createChildFrame("Demo Panel");
+        panel.setAnchor(WidgeCraft::Anchor::TopLeft);
+        panel.setPosition(24.0f, 24.0f);
+        panel.setSize(360.0f, 236.0f);
+        panel.setBackgroundColor({ 0.075f, 0.095f, 0.13f, 0.96f });
+        panel.setBorderVisible(true);
+        panel.setBorderColor({ 0.26f, 0.36f, 0.50f, 1.0f });
+        panel.setBorderThickness(1.0f);
 
-        auto& titleLabel = headerFrame.addWidget<WidgeCraft::Label>("TitleLabel", "WidgeCraft Engine");
-        auto& actionButton = headerFrame.addWidget<WidgeCraft::Button>("ActionButton", "Start Crafting");
+        auto& title = panel.addWidget<WidgeCraft::Label>("Title", "WidgeCraft");
+        title.setAnchor(WidgeCraft::Anchor::TopLeft);
+        title.setPosition(18.0f, 16.0f);
+        title.setTextSize(34.0f);
+        title.setColor({ 0.72f, 0.90f, 1.0f, 1.0f });
 
-        titleLabel.setColor({ 1.0f, 1.0f, 0.9f });
-        actionButton.setTextColor({ 0.8f, 0.9f, 1.0f });
-        actionButton.setBackgroundVisible(false);
+        auto& subtitle = panel.addWidget<WidgeCraft::Label>(
+            "Subtitle",
+            "Retained UI • batched primitives • SDF text");
+        subtitle.setAnchor(WidgeCraft::Anchor::TopLeft);
+        subtitle.setPosition(18.0f, 62.0f);
+        subtitle.setTextSize(16.0f);
+        subtitle.setColor({ 0.68f, 0.73f, 0.82f, 1.0f });
 
-        const float baseTextSize = wc.getTextRenderer().getBasePixelHeight();
-        titleLabel.setTextSize(baseTextSize);
-        actionButton.setTextSize(baseTextSize * 0.5f);
-
-        wc.setUpdateCallback([&](WidgeCraft::WidgeCraft& app) {
-            auto& window = app.getWindow();
-            auto& textRenderer = app.getTextRenderer();
-
-            const float margin = 40.0f;
-            const float headerHeight = textRenderer.getLineHeight() * 3.0f;
-            headerFrame.setSize(static_cast<float>(window.getWidth()) - margin * 2.0f, headerHeight);
-            headerFrame.setPosition(margin, static_cast<float>(window.getHeight()) - headerHeight - margin);
-
-            const float headerTopBaseline = headerFrame.getSize().y - textRenderer.getAscent() - 10.0f;
-            titleLabel.setPosition(0.0f, headerTopBaseline);
-            actionButton.setPosition(0.0f, headerTopBaseline - textRenderer.getLineHeight());
+        bool showGrid = true;
+        auto& gridCheckbox = panel.addWidget<WidgeCraft::Checkbox>("Grid Toggle", "Show primitive grid", showGrid);
+        gridCheckbox.setAnchor(WidgeCraft::Anchor::TopLeft);
+        gridCheckbox.setPosition(18.0f, 102.0f);
+        gridCheckbox.setTextSize(17.0f);
+        gridCheckbox.setOnChanged([&](bool checked) {
+            showGrid = checked;
         });
 
-        wc.Run();
-    }
-    catch (const std::exception& e) {
-        std::cerr << "Error: " << e.what() << "\n";
-        std::cin.get();
-        return -1;
+        auto& status = panel.addWidget<WidgeCraft::Label>("Status", "Button ready");
+        status.setAnchor(WidgeCraft::Anchor::BottomLeft);
+        status.setPosition(176.0f, 28.0f);
+        status.setTextSize(16.0f);
+        status.setColor({ 0.62f, 0.78f, 0.67f, 1.0f });
+
+        int clickCount = 0;
+        auto& action = panel.addWidget<WidgeCraft::Button>("Action", "Craft something");
+        action.setAnchor(WidgeCraft::Anchor::BottomLeft);
+        action.setPosition(18.0f, 18.0f);
+        action.setSize(142.0f, 44.0f);
+        action.setTextSize(17.0f);
+        action.setOnClick([&]() {
+            ++clickCount;
+            status.setText("Clicked " + std::to_string(clickCount) + (clickCount == 1 ? " time" : " times"));
+        });
+
+        app.setRenderCallback([&](WidgeCraft::WidgeCraft& engine) {
+            auto& shapes = engine.getShapeRenderer();
+            auto& text = engine.getTextRenderer();
+            const float width = static_cast<float>(engine.getWindow().getWidth());
+            const float height = static_cast<float>(engine.getWindow().getHeight());
+
+            if (showGrid) {
+                for (float x = 0.0f; x <= width; x += 40.0f) {
+                    shapes.drawLine(x, 0.0f, x, height, 1.0f, { 0.10f, 0.13f, 0.18f, 0.75f });
+                }
+                for (float y = 0.0f; y <= height; y += 40.0f) {
+                    shapes.drawLine(0.0f, y, width, y, 1.0f, { 0.10f, 0.13f, 0.18f, 0.75f });
+                }
+            }
+
+            const float centerX = width * 0.67f;
+            const float centerY = height * 0.48f;
+            const float angle = static_cast<float>(engine.getElapsedTime()) * 0.8f;
+
+            shapes.drawFilledCircle(centerX, centerY, 86.0f, { 0.08f, 0.34f, 0.46f, 0.65f });
+            shapes.drawCircleOutline(centerX, centerY, 86.0f, 4.0f, { 0.38f, 0.83f, 1.0f, 1.0f });
+            shapes.drawLine(
+                centerX,
+                centerY,
+                centerX + std::cos(angle) * 72.0f,
+                centerY + std::sin(angle) * 72.0f,
+                7.0f,
+                { 1.0f, 0.72f, 0.28f, 1.0f });
+            shapes.drawPoint(centerX, centerY, 16.0f, { 1.0f, 0.95f, 0.78f, 1.0f });
+
+            shapes.drawTriangle(
+                { centerX - 145.0f, centerY - 150.0f },
+                { centerX - 35.0f, centerY - 150.0f },
+                { centerX - 90.0f, centerY - 55.0f },
+                { 0.62f, 0.28f, 0.82f, 0.85f });
+            shapes.drawRectOutline(
+                centerX + 25.0f,
+                centerY - 150.0f,
+                150.0f,
+                94.0f,
+                5.0f,
+                { 0.32f, 0.80f, 0.55f, 1.0f });
+
+            text.renderText("SDF at 12 px", centerX - 175.0f, height - 70.0f, 12.0f, { 0.78f, 0.83f, 0.92f, 1.0f });
+            text.renderText("SDF at 30 px", centerX - 175.0f, height - 112.0f, 30.0f, { 0.80f, 0.92f, 1.0f, 1.0f });
+            text.renderText("SDF", centerX - 175.0f, 72.0f, 92.0f, { 0.20f, 0.62f, 0.84f, 0.34f });
+        });
+
+        app.Run(60);
+    } catch (const std::exception& exception) {
+        std::cerr << "WidgeCraft failed: " << exception.what() << '\n';
+        return 1;
     }
 
     return 0;
 }
-

--- a/tests/RaycastTests.cpp
+++ b/tests/RaycastTests.cpp
@@ -1,0 +1,65 @@
+#include "WidgeCraft/Raycast.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+
+namespace {
+    bool nearlyEqual(float lhs, float rhs, float tolerance = 1.0e-4f) {
+        return std::abs(lhs - rhs) <= tolerance;
+    }
+}
+
+int main() {
+    using namespace WidgeCraft;
+
+    {
+        const Ray ray{ { 0.0f, 0.0f, 5.0f }, { 0.0f, 0.0f, -1.0f } };
+        const Sphere sphere{ { 0.0f, 0.0f, 0.0f }, 1.0f };
+        RayHit hit{};
+        assert(raycast(ray, sphere, hit));
+        assert(nearlyEqual(hit.distance, 4.0f));
+        assert(nearlyEqual(hit.point.z, 1.0f));
+        assert(nearlyEqual(hit.normal.z, 1.0f));
+    }
+
+    {
+        const Ray ray{ { -2.0f, 0.0f, 0.0f }, { 1.0f, 0.0f, 0.0f } };
+        const AABB box{ { -1.0f, -1.0f, -1.0f }, { 1.0f, 1.0f, 1.0f } };
+        RayHit hit{};
+        assert(raycast(ray, box, hit));
+        assert(nearlyEqual(hit.distance, 1.0f));
+        assert(nearlyEqual(hit.normal.x, -1.0f));
+    }
+
+    {
+        const Ray ray{ { 0.0f, 2.0f, 0.0f }, { 0.0f, -1.0f, 0.0f } };
+        const Plane plane{ { 0.0f, 1.0f, 0.0f }, 0.0f };
+        RayHit hit{};
+        assert(raycast(ray, plane, hit));
+        assert(nearlyEqual(hit.distance, 2.0f));
+        assert(nearlyEqual(hit.point.y, 0.0f));
+    }
+
+    {
+        const Ray ray{ { 0.25f, 0.25f, 1.0f }, { 0.0f, 0.0f, -1.0f } };
+        const Triangle triangle{ { 0.0f, 0.0f, 0.0f }, { 1.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f } };
+        RayHit hit{};
+        assert(raycast(ray, triangle, hit));
+        assert(nearlyEqual(hit.distance, 1.0f));
+        assert(nearlyEqual(hit.u, 0.25f));
+        assert(nearlyEqual(hit.v, 0.25f));
+    }
+
+    {
+        const Mat4 identity = Mat4::identity();
+        const Ray ray = screenPointToRay(400.0f, 300.0f, 800.0f, 600.0f, identity, identity);
+        assert(nearlyEqual(ray.origin.x, 0.0f));
+        assert(nearlyEqual(ray.origin.y, 0.0f));
+        assert(nearlyEqual(ray.origin.z, -1.0f));
+        assert(nearlyEqual(ray.direction.z, 1.0f));
+    }
+
+    std::cout << "Raycast tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## What this changes

This is a broad foundation pass that turns the existing rendering prototype into a more coherent reusable engine library.

### Rendering
- Replaces immediate per-rectangle uploads with a batched primitive renderer.
- Adds points, thick lines, triangles, filled/outlined rectangles and adaptive circles.
- Rebuilds SDF text into a glyph batch with mipmaps, derivative smoothing, kerning, UTF-8 decoding for a useful default atlas, alpha colour and improved measurement.

### Retained UI and input
- Adds frame-based keyboard/mouse transitions, pointer delta and wheel delta.
- Adds consistent anchors for frames and widgets.
- Adds clipped frame hierarchies using scissor rectangles.
- Adds widget lookup/removal and duplicate-name protection.
- Adds interactive buttons and a built-in checkbox.
- Removes the label debug-outline behaviour.

### Ray queries
- Adds rays, hit records, spheres, AABBs, planes and triangles.
- Adds sphere/AABB/plane/triangle intersections.
- Adds screen-point-to-world-ray construction and matrix inversion.
- Adds non-graphical unit tests for the ray module.

### Project structure
- Builds a reusable `WidgeCraft::Engine` static library.
- Keeps a separate interactive showcase executable.
- Adds Win32 Release test targets and fixes CI so it no longer tries to launch a GUI app on the runner.
- Adds a README and one-click VS2022 Win32 solution generation batch file.

## Validation
- The branch is configured for the repository's supported Visual Studio 2022 Win32 Release preset.
- Ray queries are covered by a standalone CTest target that does not require an OpenGL window.
- GitHub Actions will build the full engine/showcase and run the non-graphical tests on this PR.

## Deliberate scope

This establishes the core 2D/UI/text/ray foundation. A dedicated 3D model pipeline, camera system, texture/image renderer, keyboard focus/navigation and BVH acceleration remain sensible follow-on work rather than being partially bolted into this pass.