### PR TITLE
Increase SDF source resolution for sharper corners

### DIFF
--- a/include/WidgeCraft/TextRenderer.hpp
+++ b/include/WidgeCraft/TextRenderer.hpp
@@ -27,7 +27,9 @@ namespace WidgeCraft {
             float height() const { return maxY - minY; }
         };
 
-        TextRenderer(int screenWidth, int screenHeight, const std::string& fontPath, float fontPixelHeight = 64.0f);
+        // The source SDF is generated at 128 px by default. Keeping common UI
+        // sizes below the source resolution preserves sharp concave corners.
+        TextRenderer(int screenWidth, int screenHeight, const std::string& fontPath, float fontPixelHeight = 128.0f);
         ~TextRenderer();
 
         TextRenderer(const TextRenderer&) = delete;

--- a/include/WidgeCraft/WidgeCraft.hpp
+++ b/include/WidgeCraft/WidgeCraft.hpp
@@ -17,7 +17,7 @@ namespace WidgeCraft {
         using UpdateCallback = std::function<void(WidgeCraft&)>;
         using RenderCallback = std::function<void(WidgeCraft&)>;
 
-        WidgeCraft(std::string title, int width, int height, std::string fontPath = {}, float fontPixelHeight = 64.0f);
+        WidgeCraft(std::string title, int width, int height, std::string fontPath = {}, float fontPixelHeight = 128.0f);
         ~WidgeCraft() = default;
 
         WidgeCraft(const WidgeCraft&) = delete;


### PR DESCRIPTION
## What changed
- raises the default source SDF generation size from 64 px to 128 px
- keeps the existing 2048 single-channel atlas and current shader/API

## Why
The large `F` sample exposed a real concave-corner notch where each horizontal arm meets the vertical stem. That is caused by magnifying a relatively coarse single-channel distance field, not by the background grid. Rendering the 92 px sample from a 128 px source field keeps those junctions below the source resolution and substantially reduces the contour pull-in.

## Validation
The VS2022 Win32 Release build and non-graphical tests will run in CI. Final validation is visual on the target Windows/OpenGL machine.