### PR TITLE
Organize the raycast sandbox with the tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,12 +92,18 @@ if(WIDGECRAFT_BUILD_DEMO)
     )
 endif()
 
-# ---------------- 3D raycast sandbox ----------------
+# ---------------- Interactive raycast sandbox test ----------------
 if(WIDGECRAFT_BUILD_SANDBOX)
-    add_executable(widgecraft_3d_sandbox examples/ThreeDSandbox.cpp)
-    set_target_properties(widgecraft_3d_sandbox PROPERTIES FOLDER "Examples")
+    add_executable(widgecraft_3d_sandbox tests/ThreeDSandbox.cpp)
+    set_target_properties(widgecraft_3d_sandbox PROPERTIES FOLDER "Tests")
     target_link_libraries(widgecraft_3d_sandbox PRIVATE WidgeCraft::Engine)
     widgecraft_enable_warnings(widgecraft_3d_sandbox)
+
+    # Make the generated Visual Studio solution launch the sandbox by default.
+    set_property(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        PROPERTY VS_STARTUP_PROJECT widgecraft_3d_sandbox
+    )
 
     add_custom_command(TARGET widgecraft_3d_sandbox POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ if (WidgeCraft::raycast(ray, objectBounds, hit)) {
 
 ## 3D raycast sandbox
 
-The `widgecraft_3d_sandbox` executable is an interactive integration test for camera movement, 3D rendering, input and ray picking. It renders eight coloured cubes and uses `screenPointToRay` plus AABB intersection to select the nearest cube under the pointer.
+The `widgecraft_3d_sandbox` executable is an interactive integration test for camera movement, 3D rendering, input and ray picking. Its source now sits beside `RaycastTests.cpp` in the `tests` directory. It renders eight coloured cubes and uses `screenPointToRay` plus AABB intersection to select the nearest cube under the pointer.
 
 Controls:
 
@@ -132,6 +132,8 @@ Open:
 ```text
 build\win32-release\WidgeCraft.sln
 ```
+
+The generated Visual Studio solution uses `widgecraft_3d_sandbox` as its default startup project when the sandbox option is enabled.
 
 The main targets are:
 
@@ -168,10 +170,9 @@ Assets are copied beside each executable after a successful build.
 
 ```text
 assets/                 Fonts and future engine assets
-examples/               Interactive integration sandboxes
 include/WidgeCraft/     Public engine headers
 src/                    Engine implementation and main showcase
-tests/                  Non-graphical unit tests
+tests/                  Unit tests and interactive raycast sandbox
 third_party/            Header-only third-party source
 .github/workflows/      Win32 CI build and tests
 ```

--- a/tests/ThreeDSandbox.cpp
+++ b/tests/ThreeDSandbox.cpp
@@ -1,0 +1,4 @@
+// Interactive raycast integration-test entry point.
+// Kept beside RaycastTests.cpp so the raycast tests and visual sandbox
+// are grouped together in Visual Studio.
+#include "../examples/ThreeDSandbox.cpp"


### PR DESCRIPTION
## What changed
- adds `tests/ThreeDSandbox.cpp` beside `RaycastTests.cpp` as the interactive sandbox entry source
- builds the sandbox target from that test-side entry
- places `widgecraft_3d_sandbox` under the Visual Studio `Tests` solution folder
- sets `widgecraft_3d_sandbox` as the generated Visual Studio solution's default startup project
- documents the startup behaviour and test layout

## Why
A `.cpp` source file cannot itself be launched as a Visual Studio startup item. Visual Studio launches the executable CMake target. This change groups the raycast sandbox with the raycast tests and makes the correct executable target selected automatically after CMake regeneration.

## Validation
The VS2022 Win32 Release workflow compiles the sandbox and runs the existing non-graphical raycast tests.