### PR TITLE
Preserve 2D scene aspect ratio on resize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(WIDGECRAFT_ENGINE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/ui/Frame.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/ui/Widget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Scene.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/SceneViewport2D.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Raycast.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/render/ShaderProgram.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/primitives/Types.hpp

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ include/WidgeCraft/
   input/        Keyboard, mouse and pointer state
   window/       Window, framebuffer and client-area ownership
   ui/           Frames and retained UI widgets
-  scene/        Scene lifecycle and world queries such as raycasting
+  scene/        Scene lifecycle, 2D viewports and world queries
   render/       Shader-program and rendering-pipeline utilities
   primitives/   Maths/types, Shapes2D, Shapes3D and SDF text
 
@@ -30,6 +30,21 @@ Compatibility headers remain at `include/WidgeCraft/*.hpp`, but new code should 
 ## Primitive drawing
 
 `Shapes2D` supports points, thick lines, triangles, rectangles and circles. The `ShapeStyle2D` helpers combine fill colour, edge colour and edge thickness in one call.
+
+A `SceneViewport2D` maps a fixed logical canvas into the current client area with one uniform scale. This keeps all 2D scene geometry, dimensions and edge thicknesses proportional when the window aspect ratio changes:
+
+```cpp
+WidgeCraft::SceneViewport2D viewport(1100.0f, 720.0f);
+
+viewport.resize(windowWidth, windowHeight);
+auto& shapes = app.getShapes2D();
+shapes.setTransform(viewport.getOffset(), viewport.getScale());
+
+// Draw in the fixed 1100 x 720 logical scene.
+shapes.drawCircle({ 200.0f, 500.0f }, 90.0f, style);
+```
+
+The retained UI automatically returns to native client-pixel coordinates after scene drawing.
 
 `Shapes3D` supports lines, triangles, quads, boxes and cubes. Set its view-projection matrix before queuing 3D geometry:
 

--- a/include/WidgeCraft/WidgeCraft.hpp
+++ b/include/WidgeCraft/WidgeCraft.hpp
@@ -8,6 +8,7 @@
 #include "WidgeCraft/render/ShaderProgram.hpp"
 #include "WidgeCraft/scene/Raycast.hpp"
 #include "WidgeCraft/scene/Scene.hpp"
+#include "WidgeCraft/scene/SceneViewport2D.hpp"
 #include "WidgeCraft/ui/Frame.hpp"
 #include "WidgeCraft/ui/Widget.hpp"
 #include "WidgeCraft/window/Window.hpp"

--- a/include/WidgeCraft/primitives/Shapes2D.hpp
+++ b/include/WidgeCraft/primitives/Shapes2D.hpp
@@ -31,6 +31,14 @@ namespace WidgeCraft {
         void beginFrame();
         void flush();
 
+        // Applies a uniform logical-scene transform while geometry is queued.
+        // Vertex positions, dimensions and edge thicknesses all receive the
+        // same scale, preserving shape aspect ratios.
+        void setTransform(const Vec2& offset, float uniformScale);
+        void resetTransform();
+        Vec2 getTransformOffset() const { return m_transformOffset; }
+        float getTransformScale() const { return m_transformScale; }
+
         void reserve(std::size_t triangleCount);
 
         void drawPoint(float x, float y, float size, const Color& color);
@@ -121,6 +129,8 @@ namespace WidgeCraft {
         int m_uniformScreenSize = -1;
         float m_screenWidth = 0.0f;
         float m_screenHeight = 0.0f;
+        Vec2 m_transformOffset{};
+        float m_transformScale = 1.0f;
         std::vector<Vertex> m_vertices;
     };
 

--- a/include/WidgeCraft/scene/SceneViewport2D.hpp
+++ b/include/WidgeCraft/scene/SceneViewport2D.hpp
@@ -58,7 +58,8 @@ namespace WidgeCraft {
         }
 
         Rect toScreen(const Rect& sceneRect) const {
-            const Vec2 bottomLeft = toScreen({ sceneRect.x, sceneRect.y });
+            const Vec2 bottomLeft = toScreen(
+                Vec2{ sceneRect.x, sceneRect.y });
             return {
                 bottomLeft.x,
                 bottomLeft.y,

--- a/include/WidgeCraft/scene/SceneViewport2D.hpp
+++ b/include/WidgeCraft/scene/SceneViewport2D.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "WidgeCraft/primitives/Types.hpp"
+
+#include <algorithm>
+
+namespace WidgeCraft {
+
+    // Maps a fixed logical 2D scene into the current client area using one
+    // uniform scale. Extra horizontal or vertical space is centred, so scene
+    // geometry keeps its intended aspect ratio on every window shape.
+    class SceneViewport2D {
+    public:
+        SceneViewport2D(float logicalWidth, float logicalHeight) {
+            setLogicalSize(logicalWidth, logicalHeight);
+        }
+
+        void setLogicalSize(float width, float height) {
+            m_logicalSize = {
+                std::max(width, 1.0f),
+                std::max(height, 1.0f)
+            };
+            resize(m_screenSize.x, m_screenSize.y);
+        }
+
+        void resize(float screenWidth, float screenHeight) {
+            m_screenSize = {
+                std::max(screenWidth, 0.0f),
+                std::max(screenHeight, 0.0f)
+            };
+
+            if (m_screenSize.x <= 0.0f || m_screenSize.y <= 0.0f) {
+                m_scale = 0.0f;
+                m_offset = {};
+                return;
+            }
+
+            m_scale = std::min(
+                m_screenSize.x / m_logicalSize.x,
+                m_screenSize.y / m_logicalSize.y);
+
+            const Vec2 displayedSize = m_logicalSize * m_scale;
+            m_offset = {
+                (m_screenSize.x - displayedSize.x) * 0.5f,
+                (m_screenSize.y - displayedSize.y) * 0.5f
+            };
+        }
+
+        Vec2 toScreen(const Vec2& scenePosition) const {
+            return m_offset + scenePosition * m_scale;
+        }
+
+        Vec2 toScene(const Vec2& screenPosition) const {
+            if (m_scale <= 0.0f) {
+                return {};
+            }
+            return (screenPosition - m_offset) / m_scale;
+        }
+
+        Rect toScreen(const Rect& sceneRect) const {
+            const Vec2 bottomLeft = toScreen({ sceneRect.x, sceneRect.y });
+            return {
+                bottomLeft.x,
+                bottomLeft.y,
+                sceneRect.width * m_scale,
+                sceneRect.height * m_scale
+            };
+        }
+
+        float scaleLength(float sceneLength) const {
+            return sceneLength * m_scale;
+        }
+
+        Rect getScreenRect() const {
+            return {
+                m_offset.x,
+                m_offset.y,
+                m_logicalSize.x * m_scale,
+                m_logicalSize.y * m_scale
+            };
+        }
+
+        Vec2 getLogicalSize() const { return m_logicalSize; }
+        Vec2 getScreenSize() const { return m_screenSize; }
+        Vec2 getOffset() const { return m_offset; }
+        float getScale() const { return m_scale; }
+
+    private:
+        Vec2 m_logicalSize{ 1.0f, 1.0f };
+        Vec2 m_screenSize{};
+        Vec2 m_offset{};
+        float m_scale = 0.0f;
+    };
+
+} // namespace WidgeCraft

--- a/sandbox/UiDemo.cpp
+++ b/sandbox/UiDemo.cpp
@@ -6,11 +6,18 @@
 
 int main() {
     try {
+        constexpr float sceneWidth = 1100.0f;
+        constexpr float sceneHeight = 720.0f;
+
         WidgeCraft::WidgeCraft app(
             "WidgeCraft UI Sandbox",
-            1100,
-            720);
+            static_cast<int>(sceneWidth),
+            static_cast<int>(sceneHeight));
         app.setClearColor({ 0.030f, 0.040f, 0.060f, 1.0f });
+
+        WidgeCraft::SceneViewport2D sceneViewport(
+            sceneWidth,
+            sceneHeight);
 
         auto& root = app.getRootFrame();
         root.setBackgroundVisible(false);
@@ -34,7 +41,7 @@ int main() {
 
         auto& subtitle = panel.addWidget<WidgeCraft::Label>(
             "Subtitle",
-            "Frames, widgets, Shapes2D and SDF text");
+            "Frames, widgets and a fixed-aspect 2D scene");
         subtitle.setAnchor(WidgeCraft::Anchor::TopLeft);
         subtitle.setPosition(24.0f, 62.0f);
         subtitle.setTextSize(16.0f);
@@ -51,7 +58,7 @@ int main() {
 
         auto& status = statusCard.addWidget<WidgeCraft::Label>(
             "Status",
-            "The UI is ready.");
+            "Resize the window: scene shapes keep their proportions.");
         status.setAnchor(WidgeCraft::Anchor::CenterLeft);
         status.setPosition(18.0f, 0.0f);
         status.setSize(430.0f, 34.0f);
@@ -114,13 +121,18 @@ int main() {
             const float height = static_cast<float>(
                 engine.getWindow().getHeight());
 
+            sceneViewport.resize(width, height);
+            shapes.setTransform(
+                sceneViewport.getOffset(),
+                sceneViewport.getScale());
+
             WidgeCraft::ShapeStyle2D circleStyle;
             circleStyle.fillColor = { 0.06f, 0.20f, 0.30f, 0.75f };
             circleStyle.edgeColor = { 0.25f, 0.68f, 0.92f, 0.9f };
             circleStyle.edgeThickness = 3.0f;
             circleStyle.edgeVisible = true;
             shapes.drawCircle(
-                { width * 0.18f, height * 0.74f },
+                { sceneWidth * 0.18f, sceneHeight * 0.74f },
                 92.0f,
                 circleStyle);
 
@@ -130,7 +142,12 @@ int main() {
             rectangleStyle.edgeThickness = 4.0f;
             rectangleStyle.edgeVisible = true;
             shapes.drawRect(
-                { width * 0.74f, height * 0.18f, 170.0f, 116.0f },
+                {
+                    sceneWidth * 0.74f,
+                    sceneHeight * 0.18f,
+                    170.0f,
+                    116.0f
+                },
                 rectangleStyle);
 
             WidgeCraft::ShapeStyle2D triangleStyle;
@@ -139,9 +156,9 @@ int main() {
             triangleStyle.edgeThickness = 4.0f;
             triangleStyle.edgeVisible = true;
             shapes.drawTriangle(
-                { width * 0.79f, height * 0.78f },
-                { width * 0.90f, height * 0.58f },
-                { width * 0.68f, height * 0.58f },
+                { sceneWidth * 0.79f, sceneHeight * 0.78f },
+                { sceneWidth * 0.90f, sceneHeight * 0.58f },
+                { sceneWidth * 0.68f, sceneHeight * 0.58f },
                 triangleStyle);
         });
 

--- a/src/core/WidgeCraft.cpp
+++ b/src/core/WidgeCraft.cpp
@@ -130,11 +130,14 @@ namespace WidgeCraft {
             m_renderCallback(*this);
         }
 
-        // World geometry first, then the pixel-space scene and retained UI.
+        // World geometry first, then the transformed 2D scene.
         m_shapes3D.flush();
         m_shapes2D.flush();
         m_textRenderer.flush();
 
+        // Retained UI always uses native client pixels, regardless of any
+        // logical scene transform used by the callback or Scene.
+        m_shapes2D.resetTransform();
         m_window.getRootFrame().render(
             m_textRenderer,
             m_shapes2D,

--- a/src/primitives/Shapes2D.cpp
+++ b/src/primitives/Shapes2D.cpp
@@ -1,4 +1,4 @@
-#include "WidgeCraft/ShapeRenderer.hpp"
+#include "WidgeCraft/primitives/Shapes2D.hpp"
 
 #include <glad/glad.h>
 
@@ -136,8 +136,22 @@ namespace WidgeCraft {
         m_screenHeight = height;
     }
 
+    void ShapeRenderer::setTransform(
+        const Vec2& offset,
+        float uniformScale) {
+
+        m_transformOffset = offset;
+        m_transformScale = std::max(uniformScale, 0.0f);
+    }
+
+    void ShapeRenderer::resetTransform() {
+        m_transformOffset = {};
+        m_transformScale = 1.0f;
+    }
+
     void ShapeRenderer::beginFrame() {
         m_vertices.clear();
+        resetTransform();
     }
 
     void ShapeRenderer::flush() {
@@ -269,7 +283,16 @@ namespace WidgeCraft {
     }
 
     void ShapeRenderer::addVertex(const Vec2& position, const Color& color) {
-        m_vertices.push_back({ position.x, position.y, color.r, color.g, color.b, color.a });
+        const Vec2 transformed =
+            m_transformOffset + position * m_transformScale;
+        m_vertices.push_back({
+            transformed.x,
+            transformed.y,
+            color.r,
+            color.g,
+            color.b,
+            color.a
+        });
     }
 
     void ShapeRenderer::moveFrom(ShapeRenderer&& other) noexcept {
@@ -279,6 +302,8 @@ namespace WidgeCraft {
         m_uniformScreenSize = other.m_uniformScreenSize;
         m_screenWidth = other.m_screenWidth;
         m_screenHeight = other.m_screenHeight;
+        m_transformOffset = other.m_transformOffset;
+        m_transformScale = other.m_transformScale;
         m_vertices = std::move(other.m_vertices);
 
         other.m_vao = 0;
@@ -287,6 +312,7 @@ namespace WidgeCraft {
         other.m_uniformScreenSize = -1;
         other.m_screenWidth = 0.0f;
         other.m_screenHeight = 0.0f;
+        other.resetTransform();
     }
 
     void ShapeRenderer::cleanup() {


### PR DESCRIPTION
## What changed
- adds `SceneViewport2D`, a fixed logical 2D canvas that maps into the client area with one uniform scale and centred spare space
- adds a uniform offset/scale transform to `Shapes2D`
- applies the transform while vertices are queued, so shape dimensions and edge thicknesses remain proportional
- resets `Shapes2D` to native client pixels before retained UI rendering
- updates the UI sandbox to draw its decoration in a fixed 1100 x 720 logical scene
- documents the viewport workflow

## Root cause
The triangle renderer was not distorting its own geometry. The sandbox calculated each triangle vertex independently from the live window width and height, so resizing changed its X and Y dimensions at different rates. The circle radius and rectangle dimensions were fixed pixel values, which made the problem appear triangle-specific.

## Validation
The VS2022 Win32 Release workflow must configure and build the engine and UI sandbox. Final resize behaviour still needs a visual check on the Windows/OpenGL target machine.