### PR TITLE
Add unified clipped model viewport for 2D and 3D

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.25)
-project(WidgeCraft VERSION 0.3.0 LANGUAGES CXX)
+project(WidgeCraft VERSION 0.4.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -49,6 +49,9 @@ set(WIDGECRAFT_ENGINE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/ui/Frame.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/ui/Widget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Scene.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Camera2D.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Camera3D.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/ModelViewport.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/SceneViewport2D.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Raycast.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/render/ShaderProgram.hpp

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WidgeCraft
 
-WidgeCraft is a Windows-focused C++17/OpenGL 3.3 engine foundation with retained UI, SDF text, batched 2D primitives, basic 3D primitives and ray queries. The supported development target is Visual Studio 2022, Win32, Release.
+WidgeCraft is a Windows-focused C++17/OpenGL 3.3 engine foundation with retained UI, SDF text, batched 2D primitives, basic 3D primitives, clipped model viewports and ray queries. The supported development target is Visual Studio 2022, Win32, Release.
 
 ## Project layout
 
@@ -9,7 +9,7 @@ include/WidgeCraft/
   input/        Keyboard, mouse and pointer state
   window/       Window, framebuffer and client-area ownership
   ui/           Frames and retained UI widgets
-  scene/        Scene lifecycle, 2D viewports and world queries
+  scene/        Cameras, model viewports, scene lifecycle and raycasting
   render/       Shader-program and rendering-pipeline utilities
   primitives/   Maths/types, Shapes2D, Shapes3D and SDF text
 
@@ -27,42 +27,86 @@ sandbox/        Launchable visual integration demos
 
 Compatibility headers remain at `include/WidgeCraft/*.hpp`, but new code should use the organised paths or include the aggregate `WidgeCraft/WidgeCraft.hpp` header.
 
+## Model viewport
+
+`ModelViewport` is the standard scene/model area for both 2D and 3D content. It owns a framebuffer rectangle, a uniformly scaled `Camera2D`, an aspect-correct perspective or orthographic `Camera3D`, world/screen conversions, ray creation and scene-text helpers.
+
+```cpp
+WidgeCraft::ModelViewport viewport;
+viewport.setScreenRect(modelFrame.getAbsoluteRect());
+
+viewport.getCamera2D().setPosition({ 0.0f, 0.0f });
+viewport.getCamera2D().setZoom(1.0f);
+
+viewport.getCamera3D().setPosition({ 6.0f, 4.0f, 9.0f });
+viewport.getCamera3D().setTarget({ 0.0f, 0.0f, 0.0f });
+viewport.getCamera3D().setPerspective(55.0f);
+
+app.setRenderCallback([&](WidgeCraft::WidgeCraft& engine) {
+    engine.useModelViewport(viewport);
+
+    engine.getShapes2D().drawCircle(
+        { 0.0f, 0.0f },
+        100.0f,
+        circleStyle);
+
+    engine.getShapes3D().drawCube(
+        { 0.0f, 0.0f, 0.0f },
+        1.5f,
+        cubeStyle);
+
+    viewport.drawWorldText2D(
+        engine.getTextRenderer(),
+        "Map label",
+        { 120.0f, 80.0f },
+        24.0f);
+
+    viewport.drawLabel3D(
+        engine.getTextRenderer(),
+        "Cube",
+        { 0.0f, 1.0f, 0.0f },
+        16.0f);
+});
+```
+
+The engine uses the model rectangle as the OpenGL viewport for 3D and as the scissor rectangle for every scene pass. Large maps, terrain and projected labels are clipped at the model boundary. It then restores the full framebuffer before drawing retained UI, so UI frames, shapes and text never inherit scene transforms or stretching.
+
+### 2D camera
+
+`Camera2D::zoom` is pixels per world unit. Resizing the model area reveals more or less world space without changing object proportions.
+
+```cpp
+viewport.getCamera2D().setPosition({ 500.0f, 300.0f });
+viewport.getCamera2D().setZoom(1.5f);
+
+const WidgeCraft::Vec2 world =
+    viewport.screenToWorld2D(engine.getInput().getMousePosition());
+```
+
+The older `SceneViewport2D` fixed-canvas helper remains available for compatibility, but `ModelViewport` is preferred for model editors, maps and visualisation tools.
+
+### 3D camera and picking
+
+The 3D projection always uses the current model rectangle aspect ratio.
+
+```cpp
+WidgeCraft::Ray ray = viewport.screenPointToRay3D(
+    engine.getInput().getMousePosition());
+```
+
+`drawLabel3D` keeps a projected object label at a fixed pixel size. `drawWorldText3D` creates a camera-facing label whose size is derived from a requested world height.
+
 ## Primitive drawing
 
-`Shapes2D` supports points, thick lines, triangles, rectangles and circles. The `ShapeStyle2D` helpers combine fill colour, edge colour and edge thickness in one call.
+`Shapes2D` supports points, thick lines, triangles, rectangles and circles. `ShapeStyle2D` combines fill colour, edge colour and edge thickness.
 
-A `SceneViewport2D` maps a fixed logical canvas into the current client area with one uniform scale. This keeps all 2D scene geometry, dimensions and edge thicknesses proportional when the window aspect ratio changes:
-
-```cpp
-WidgeCraft::SceneViewport2D viewport(1100.0f, 720.0f);
-
-viewport.resize(windowWidth, windowHeight);
-auto& shapes = app.getShapes2D();
-shapes.setTransform(viewport.getOffset(), viewport.getScale());
-
-// Draw in the fixed 1100 x 720 logical scene.
-shapes.drawCircle({ 200.0f, 500.0f }, 90.0f, style);
-```
-
-The retained UI automatically returns to native client-pixel coordinates after scene drawing.
-
-`Shapes3D` supports lines, triangles, quads, boxes and cubes. Set its view-projection matrix before queuing 3D geometry:
-
-```cpp
-app.getShapes3D().setViewProjection(projection * view);
-app.getShapes3D().drawCube(
-    { 0.0f, 0.0f, -4.0f },
-    1.5f,
-    WidgeCraft::ShapeStyle3D{});
-```
-
-The 3D edge thickness uses OpenGL line width and is therefore subject to the graphics driver's supported line-width range.
+`Shapes3D` supports lines, triangles, quads, boxes and cubes. `ShapeStyle3D` provides fill and edge styling. The 3D edge thickness uses OpenGL line width and is subject to the graphics driver's supported range.
 
 ## Scene and UI
 
-`Scene` provides optional attach, detach, update and render hooks. Existing callback-based update/render code remains supported.
+`Scene` provides optional attach, detach, update and render hooks. Callback-based update/render code remains supported.
 
-The retained UI contains `Frame`, `Label`, `Button` and `Checkbox`. UI drawing uses `Shapes2D` and `TextRenderer` internally.
+The retained UI contains `Frame`, `Label`, `Button` and `Checkbox`. UI rendering is isolated from model-viewport transforms and clipping.
 
 ## Generate the Visual Studio solution
 
@@ -84,11 +128,7 @@ Then open or reload:
 build\win32-release\WidgeCraft.sln
 ```
 
-The generated solution sets `widgecraft_ui_sandbox` as the startup project. The only launchable demo currently retained is:
-
-```text
-build\win32-release\Release\widgecraft_ui_sandbox.exe
-```
+The generated solution sets `widgecraft_ui_sandbox` as the startup project.
 
 ## Build
 

--- a/include/WidgeCraft/WidgeCraft.hpp
+++ b/include/WidgeCraft/WidgeCraft.hpp
@@ -6,6 +6,9 @@
 #include "WidgeCraft/primitives/TextRenderer.hpp"
 #include "WidgeCraft/primitives/Types.hpp"
 #include "WidgeCraft/render/ShaderProgram.hpp"
+#include "WidgeCraft/scene/Camera2D.hpp"
+#include "WidgeCraft/scene/Camera3D.hpp"
+#include "WidgeCraft/scene/ModelViewport.hpp"
 #include "WidgeCraft/scene/Raycast.hpp"
 #include "WidgeCraft/scene/Scene.hpp"
 #include "WidgeCraft/scene/SceneViewport2D.hpp"
@@ -54,6 +57,17 @@ namespace WidgeCraft {
         Scene* getScene() { return m_scene.get(); }
         const Scene* getScene() const { return m_scene.get(); }
 
+        // Selects one clipped model area for the current render frame.
+        // Geometry queued after this call uses the viewport's 2D and 3D cameras.
+        void useModelViewport(const ModelViewport& viewport);
+        void clearModelViewport();
+        bool hasActiveModelViewport() const {
+            return m_modelViewportActive;
+        }
+        Rect getActiveModelViewportRect() const {
+            return m_modelViewportRect;
+        }
+
         void setClearColor(Color color) { m_clearColor = color; }
         Color getClearColor() const { return m_clearColor; }
 
@@ -93,6 +107,8 @@ namespace WidgeCraft {
         UpdateCallback m_updateCallback;
         RenderCallback m_renderCallback;
         std::unique_ptr<Scene> m_scene;
+        Rect m_modelViewportRect{};
+        bool m_modelViewportActive = false;
         float m_deltaTime = 0.0f;
         double m_elapsedTime = 0.0;
         int m_targetFrameRate = 60;

--- a/include/WidgeCraft/scene/Camera2D.hpp
+++ b/include/WidgeCraft/scene/Camera2D.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "WidgeCraft/primitives/Types.hpp"
+
+#include <algorithm>
+
+namespace WidgeCraft {
+
+    class Camera2D {
+    public:
+        void setPosition(const Vec2& position) { m_position = position; }
+        Vec2 getPosition() const { return m_position; }
+
+        void pan(const Vec2& amount) { m_position += amount; }
+
+        void setZoom(float pixelsPerWorldUnit) {
+            m_zoom = std::max(pixelsPerWorldUnit, 0.0001f);
+        }
+        float getZoom() const { return m_zoom; }
+
+        Vec2 worldToScreen(const Vec2& worldPosition, const Rect& viewport) const {
+            const Vec2 center{
+                viewport.x + viewport.width * 0.5f,
+                viewport.y + viewport.height * 0.5f
+            };
+            return center + (worldPosition - m_position) * m_zoom;
+        }
+
+        Vec2 screenToWorld(const Vec2& screenPosition, const Rect& viewport) const {
+            const Vec2 center{
+                viewport.x + viewport.width * 0.5f,
+                viewport.y + viewport.height * 0.5f
+            };
+            return m_position + (screenPosition - center) / m_zoom;
+        }
+
+        Vec2 getRenderOffset(const Rect& viewport) const {
+            const Vec2 center{
+                viewport.x + viewport.width * 0.5f,
+                viewport.y + viewport.height * 0.5f
+            };
+            return center - m_position * m_zoom;
+        }
+
+    private:
+        Vec2 m_position{};
+        float m_zoom = 1.0f;
+    };
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/scene/Camera3D.hpp
+++ b/include/WidgeCraft/scene/Camera3D.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+#include "WidgeCraft/primitives/Types.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace WidgeCraft {
+
+    enum class CameraProjection {
+        Perspective,
+        Orthographic
+    };
+
+    class Camera3D {
+    public:
+        void setPosition(const Vec3& position) { m_position = position; }
+        Vec3 getPosition() const { return m_position; }
+
+        void setTarget(const Vec3& target) { m_target = target; }
+        Vec3 getTarget() const { return m_target; }
+
+        void setUp(const Vec3& up) {
+            m_up = lengthSquared(up) > 1.0e-12f
+                ? normalized(up)
+                : Vec3{ 0.0f, 1.0f, 0.0f };
+        }
+        Vec3 getUp() const { return m_up; }
+
+        void setPerspective(
+            float verticalFieldOfViewDegrees,
+            float nearPlane = 0.1f,
+            float farPlane = 1000.0f) {
+
+            m_projection = CameraProjection::Perspective;
+            m_verticalFieldOfViewDegrees = std::clamp(
+                verticalFieldOfViewDegrees,
+                1.0f,
+                179.0f);
+            setDepthRange(nearPlane, farPlane);
+        }
+
+        void setOrthographic(
+            float visibleHeight,
+            float nearPlane = 0.1f,
+            float farPlane = 1000.0f) {
+
+            m_projection = CameraProjection::Orthographic;
+            m_orthographicHeight = std::max(visibleHeight, 0.0001f);
+            setDepthRange(nearPlane, farPlane);
+        }
+
+        CameraProjection getProjectionType() const { return m_projection; }
+
+        void setDepthRange(float nearPlane, float farPlane) {
+            m_nearPlane = std::max(nearPlane, 0.0001f);
+            m_farPlane = std::max(farPlane, m_nearPlane + 0.0001f);
+        }
+
+        float getNearPlane() const { return m_nearPlane; }
+        float getFarPlane() const { return m_farPlane; }
+        float getVerticalFieldOfViewDegrees() const {
+            return m_verticalFieldOfViewDegrees;
+        }
+        float getOrthographicHeight() const { return m_orthographicHeight; }
+
+        Mat4 getViewMatrix() const {
+            Vec3 forward = m_target - m_position;
+            if (lengthSquared(forward) <= 1.0e-12f) {
+                forward = { 0.0f, 0.0f, -1.0f };
+            } else {
+                forward = normalized(forward);
+            }
+
+            Vec3 side = cross(forward, m_up);
+            if (lengthSquared(side) <= 1.0e-12f) {
+                const Vec3 fallbackUp =
+                    std::abs(forward.y) < 0.99f
+                    ? Vec3{ 0.0f, 1.0f, 0.0f }
+                    : Vec3{ 0.0f, 0.0f, 1.0f };
+                side = cross(forward, fallbackUp);
+            }
+            side = normalized(side);
+            const Vec3 correctedUp = cross(side, forward);
+
+            Mat4 view = Mat4::identity();
+            view(0, 0) = side.x;
+            view(0, 1) = side.y;
+            view(0, 2) = side.z;
+            view(0, 3) = -dot(side, m_position);
+
+            view(1, 0) = correctedUp.x;
+            view(1, 1) = correctedUp.y;
+            view(1, 2) = correctedUp.z;
+            view(1, 3) = -dot(correctedUp, m_position);
+
+            view(2, 0) = -forward.x;
+            view(2, 1) = -forward.y;
+            view(2, 2) = -forward.z;
+            view(2, 3) = dot(forward, m_position);
+            return view;
+        }
+
+        Mat4 getProjectionMatrix(float aspectRatio) const {
+            const float aspect = std::max(aspectRatio, 0.0001f);
+
+            if (m_projection == CameraProjection::Orthographic) {
+                const float halfHeight = m_orthographicHeight * 0.5f;
+                const float halfWidth = halfHeight * aspect;
+                const float left = -halfWidth;
+                const float right = halfWidth;
+                const float bottom = -halfHeight;
+                const float top = halfHeight;
+
+                Mat4 projection = Mat4::identity();
+                projection(0, 0) = 2.0f / (right - left);
+                projection(1, 1) = 2.0f / (top - bottom);
+                projection(2, 2) = -2.0f / (m_farPlane - m_nearPlane);
+                projection(0, 3) = -(right + left) / (right - left);
+                projection(1, 3) = -(top + bottom) / (top - bottom);
+                projection(2, 3) =
+                    -(m_farPlane + m_nearPlane)
+                    / (m_farPlane - m_nearPlane);
+                return projection;
+            }
+
+            constexpr float pi = 3.14159265358979323846f;
+            const float radians =
+                m_verticalFieldOfViewDegrees * (pi / 180.0f);
+            const float focalLength = 1.0f / std::tan(radians * 0.5f);
+
+            Mat4 projection{};
+            projection(0, 0) = focalLength / aspect;
+            projection(1, 1) = focalLength;
+            projection(2, 2) =
+                (m_farPlane + m_nearPlane)
+                / (m_nearPlane - m_farPlane);
+            projection(2, 3) =
+                (2.0f * m_farPlane * m_nearPlane)
+                / (m_nearPlane - m_farPlane);
+            projection(3, 2) = -1.0f;
+            return projection;
+        }
+
+        Mat4 getViewProjection(float aspectRatio) const {
+            return getProjectionMatrix(aspectRatio) * getViewMatrix();
+        }
+
+    private:
+        Vec3 m_position{ 0.0f, 0.0f, 5.0f };
+        Vec3 m_target{};
+        Vec3 m_up{ 0.0f, 1.0f, 0.0f };
+        CameraProjection m_projection = CameraProjection::Perspective;
+        float m_verticalFieldOfViewDegrees = 60.0f;
+        float m_orthographicHeight = 10.0f;
+        float m_nearPlane = 0.1f;
+        float m_farPlane = 1000.0f;
+    };
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/scene/ModelViewport.hpp
+++ b/include/WidgeCraft/scene/ModelViewport.hpp
@@ -1,0 +1,255 @@
+#pragma once
+
+#include "WidgeCraft/primitives/Shapes2D.hpp"
+#include "WidgeCraft/primitives/Shapes3D.hpp"
+#include "WidgeCraft/primitives/TextRenderer.hpp"
+#include "WidgeCraft/scene/Camera2D.hpp"
+#include "WidgeCraft/scene/Camera3D.hpp"
+#include "WidgeCraft/scene/Raycast.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+namespace WidgeCraft {
+
+    struct ProjectedPoint3D {
+        Vec2 screen{};
+        float depth = 1.0f;
+        bool inFront = false;
+        bool visible = false;
+    };
+
+    class ModelViewport {
+    public:
+        explicit ModelViewport(const Rect& screenRect = Rect{ 0.0f, 0.0f, 1.0f, 1.0f })
+            : m_screenRect(screenRect) {
+            sanitizeRect();
+        }
+
+        void setScreenRect(const Rect& screenRect) {
+            m_screenRect = screenRect;
+            sanitizeRect();
+        }
+
+        Rect getScreenRect() const { return m_screenRect; }
+
+        float getAspectRatio() const {
+            return m_screenRect.height > 0.0f
+                ? m_screenRect.width / m_screenRect.height
+                : 1.0f;
+        }
+
+        bool contains(const Vec2& screenPosition) const {
+            return m_screenRect.contains(screenPosition);
+        }
+
+        Camera2D& getCamera2D() { return m_camera2D; }
+        const Camera2D& getCamera2D() const { return m_camera2D; }
+
+        Camera3D& getCamera3D() { return m_camera3D; }
+        const Camera3D& getCamera3D() const { return m_camera3D; }
+
+        Vec2 worldToScreen2D(const Vec2& worldPosition) const {
+            return m_camera2D.worldToScreen(worldPosition, m_screenRect);
+        }
+
+        Vec2 screenToWorld2D(const Vec2& screenPosition) const {
+            return m_camera2D.screenToWorld(screenPosition, m_screenRect);
+        }
+
+        Vec2 getShapes2DOffset() const {
+            return m_camera2D.getRenderOffset(m_screenRect);
+        }
+
+        float getShapes2DScale() const {
+            return m_camera2D.getZoom();
+        }
+
+        Mat4 getViewMatrix3D() const {
+            return m_camera3D.getViewMatrix();
+        }
+
+        Mat4 getProjectionMatrix3D() const {
+            return m_camera3D.getProjectionMatrix(getAspectRatio());
+        }
+
+        Mat4 getViewProjection3D() const {
+            return m_camera3D.getViewProjection(getAspectRatio());
+        }
+
+        Ray screenPointToRay3D(const Vec2& screenPosition) const {
+            const Vec2 local{
+                screenPosition.x - m_screenRect.x,
+                screenPosition.y - m_screenRect.y
+            };
+            return screenPointToRay(
+                local.x,
+                local.y,
+                m_screenRect.width,
+                m_screenRect.height,
+                getViewMatrix3D(),
+                getProjectionMatrix3D());
+        }
+
+        ProjectedPoint3D projectWorldToScreen3D(
+            const Vec3& worldPosition) const {
+
+            ProjectedPoint3D result{};
+            const Vec4 clip = getViewProjection3D()
+                * Vec4{
+                    worldPosition.x,
+                    worldPosition.y,
+                    worldPosition.z,
+                    1.0f
+                };
+
+            if (std::abs(clip.w) <= 1.0e-6f) {
+                return result;
+            }
+
+            result.inFront = clip.w > 0.0f;
+            if (!result.inFront) {
+                return result;
+            }
+
+            const float inverseW = 1.0f / clip.w;
+            const Vec3 ndc{
+                clip.x * inverseW,
+                clip.y * inverseW,
+                clip.z * inverseW
+            };
+
+            result.screen = {
+                m_screenRect.x
+                    + (ndc.x * 0.5f + 0.5f) * m_screenRect.width,
+                m_screenRect.y
+                    + (ndc.y * 0.5f + 0.5f) * m_screenRect.height
+            };
+            result.depth = ndc.z * 0.5f + 0.5f;
+            result.visible =
+                ndc.x >= -1.0f && ndc.x <= 1.0f
+                && ndc.y >= -1.0f && ndc.y <= 1.0f
+                && ndc.z >= -1.0f && ndc.z <= 1.0f;
+            return result;
+        }
+
+        void configureRenderers(
+            Shapes2D& shapes2D,
+            Shapes3D& shapes3D) const {
+
+            shapes2D.setTransform(
+                getShapes2DOffset(),
+                getShapes2DScale());
+            shapes3D.setViewProjection(getViewProjection3D());
+        }
+
+        void drawWorldText2D(
+            TextRenderer& textRenderer,
+            const std::string& text,
+            const Vec2& worldBaseline,
+            float worldSize,
+            Color color = Colors::White) const {
+
+            const Vec2 screen = worldToScreen2D(worldBaseline);
+            textRenderer.renderText(
+                text,
+                screen.x,
+                screen.y,
+                std::max(worldSize * m_camera2D.getZoom(), 0.0f),
+                color);
+        }
+
+        void drawLabel2D(
+            TextRenderer& textRenderer,
+            const std::string& text,
+            const Vec2& worldPosition,
+            float sizePixels,
+            Color color = Colors::White,
+            const Vec2& pixelOffset = {}) const {
+
+            const Vec2 screen = worldToScreen2D(worldPosition) + pixelOffset;
+            textRenderer.renderText(
+                text,
+                screen.x,
+                screen.y,
+                sizePixels,
+                color);
+        }
+
+        bool drawLabel3D(
+            TextRenderer& textRenderer,
+            const std::string& text,
+            const Vec3& worldPosition,
+            float sizePixels,
+            Color color = Colors::White,
+            const Vec2& pixelOffset = {}) const {
+
+            const ProjectedPoint3D projected =
+                projectWorldToScreen3D(worldPosition);
+            if (!projected.visible) {
+                return false;
+            }
+
+            textRenderer.renderText(
+                text,
+                projected.screen.x + pixelOffset.x,
+                projected.screen.y + pixelOffset.y,
+                sizePixels,
+                color);
+            return true;
+        }
+
+        bool drawWorldText3D(
+            TextRenderer& textRenderer,
+            const std::string& text,
+            const Vec3& worldPosition,
+            float worldHeight,
+            Color color = Colors::White,
+            const Vec2& pixelOffset = {}) const {
+
+            const ProjectedPoint3D baseline =
+                projectWorldToScreen3D(worldPosition);
+            if (!baseline.visible) {
+                return false;
+            }
+
+            Vec3 up = m_camera3D.getUp();
+            if (lengthSquared(up) <= 1.0e-12f) {
+                up = { 0.0f, 1.0f, 0.0f };
+            } else {
+                up = normalized(up);
+            }
+
+            const ProjectedPoint3D top = projectWorldToScreen3D(
+                worldPosition + up * worldHeight);
+            if (!top.inFront) {
+                return false;
+            }
+
+            const float pixelHeight = length(top.screen - baseline.screen);
+            if (pixelHeight <= 0.0f) {
+                return false;
+            }
+
+            textRenderer.renderText(
+                text,
+                baseline.screen.x + pixelOffset.x,
+                baseline.screen.y + pixelOffset.y,
+                pixelHeight,
+                color);
+            return true;
+        }
+
+    private:
+        void sanitizeRect() {
+            m_screenRect.width = std::max(m_screenRect.width, 1.0f);
+            m_screenRect.height = std::max(m_screenRect.height, 1.0f);
+        }
+
+        Rect m_screenRect;
+        Camera2D m_camera2D;
+        Camera3D m_camera3D;
+    };
+
+} // namespace WidgeCraft

--- a/sandbox/UiDemo.cpp
+++ b/sandbox/UiDemo.cpp
@@ -1,171 +1,220 @@
 #include "WidgeCraft/WidgeCraft.hpp"
 
+#include <algorithm>
 #include <exception>
 #include <iostream>
 #include <string>
 
 int main() {
     try {
-        constexpr float sceneWidth = 1100.0f;
-        constexpr float sceneHeight = 720.0f;
-
         WidgeCraft::WidgeCraft app(
-            "WidgeCraft UI Sandbox",
-            static_cast<int>(sceneWidth),
-            static_cast<int>(sceneHeight));
-        app.setClearColor({ 0.030f, 0.040f, 0.060f, 1.0f });
+            "WidgeCraft Model Viewport Sandbox",
+            1100,
+            720);
+        app.setClearColor({ 0.020f, 0.028f, 0.044f, 1.0f });
 
-        WidgeCraft::SceneViewport2D sceneViewport(
-            sceneWidth,
-            sceneHeight);
+        WidgeCraft::ModelViewport modelViewport;
+        modelViewport.getCamera2D().setPosition({ 0.0f, 0.0f });
+        modelViewport.getCamera2D().setZoom(1.0f);
+        modelViewport.getCamera3D().setPosition({ 6.0f, 4.5f, 9.0f });
+        modelViewport.getCamera3D().setTarget({ 0.0f, 0.0f, 0.0f });
+        modelViewport.getCamera3D().setPerspective(52.0f, 0.1f, 500.0f);
 
         auto& root = app.getRootFrame();
         root.setBackgroundVisible(false);
 
-        auto& panel = root.createChildFrame("Main Panel");
-        panel.setAnchor(WidgeCraft::Anchor::Center);
-        panel.setPosition(0.0f, 0.0f);
-        panel.setSize(520.0f, 370.0f);
-        panel.setBackgroundColor({ 0.070f, 0.090f, 0.125f, 0.97f });
+        auto& modelFrame = root.createChildFrame("Model Area");
+        modelFrame.setAnchor(WidgeCraft::Anchor::BottomLeft);
+        modelFrame.setPosition(28.0f, 28.0f);
+        modelFrame.setSize(1044.0f, 664.0f);
+        modelFrame.setBackgroundVisible(false);
+        modelFrame.setBorderVisible(true);
+        modelFrame.setBorderColor({ 0.22f, 0.43f, 0.68f, 1.0f });
+        modelFrame.setBorderThickness(3.0f);
+
+        auto& panel = root.createChildFrame("Controls");
+        panel.setAnchor(WidgeCraft::Anchor::TopLeft);
+        panel.setPosition(48.0f, 48.0f);
+        panel.setSize(360.0f, 214.0f);
+        panel.setBackgroundColor({ 0.055f, 0.072f, 0.105f, 0.96f });
         panel.setBorderVisible(true);
-        panel.setBorderColor({ 0.28f, 0.48f, 0.72f, 1.0f });
+        panel.setBorderColor({ 0.25f, 0.46f, 0.70f, 1.0f });
         panel.setBorderThickness(2.0f);
 
         auto& title = panel.addWidget<WidgeCraft::Label>(
             "Title",
-            "WidgeCraft UI Sandbox");
+            "Model Viewport");
         title.setAnchor(WidgeCraft::Anchor::TopLeft);
-        title.setPosition(24.0f, 20.0f);
-        title.setTextSize(30.0f);
-        title.setColor({ 0.74f, 0.90f, 1.0f, 1.0f });
+        title.setPosition(20.0f, 16.0f);
+        title.setTextSize(28.0f);
+        title.setColor({ 0.76f, 0.91f, 1.0f, 1.0f });
 
         auto& subtitle = panel.addWidget<WidgeCraft::Label>(
             "Subtitle",
-            "Frames, widgets and a fixed-aspect 2D scene");
+            "Clipped 2D, 3D and scene text");
         subtitle.setAnchor(WidgeCraft::Anchor::TopLeft);
-        subtitle.setPosition(24.0f, 62.0f);
-        subtitle.setTextSize(16.0f);
-        subtitle.setColor({ 0.65f, 0.71f, 0.82f, 1.0f });
+        subtitle.setPosition(20.0f, 54.0f);
+        subtitle.setTextSize(15.0f);
+        subtitle.setColor({ 0.63f, 0.72f, 0.84f, 1.0f });
 
-        auto& statusCard = panel.createChildFrame("Status Card");
-        statusCard.setAnchor(WidgeCraft::Anchor::TopLeft);
-        statusCard.setPosition(24.0f, 108.0f);
-        statusCard.setSize(472.0f, 92.0f);
-        statusCard.setBackgroundColor({ 0.045f, 0.060f, 0.085f, 1.0f });
-        statusCard.setBorderVisible(true);
-        statusCard.setBorderColor({ 0.16f, 0.24f, 0.34f, 1.0f });
-        statusCard.setBorderThickness(1.0f);
-
-        auto& status = statusCard.addWidget<WidgeCraft::Label>(
+        auto& status = panel.addWidget<WidgeCraft::Label>(
             "Status",
-            "Resize the window: scene shapes keep their proportions.");
-        status.setAnchor(WidgeCraft::Anchor::CenterLeft);
-        status.setPosition(18.0f, 0.0f);
-        status.setSize(430.0f, 34.0f);
-        status.setTextSize(18.0f);
-        status.setColor({ 0.66f, 0.88f, 0.72f, 1.0f });
+            "Resize the window or change 2D zoom.");
+        status.setAnchor(WidgeCraft::Anchor::TopLeft);
+        status.setPosition(20.0f, 86.0f);
+        status.setSize(320.0f, 28.0f);
+        status.setTextSize(15.0f);
+        status.setColor({ 0.67f, 0.88f, 0.72f, 1.0f });
 
-        bool showDecoration = true;
-        int clickCount = 0;
+        float cameraZoom = 1.0f;
+        bool show3D = true;
 
-        auto& action = panel.addWidget<WidgeCraft::Button>(
-            "Action",
-            "Press me");
-        action.setAnchor(WidgeCraft::Anchor::BottomLeft);
-        action.setPosition(24.0f, 30.0f);
-        action.setSize(138.0f, 46.0f);
-        action.setTextSize(17.0f);
-        action.setOnClick([&]() {
-            ++clickCount;
-            status.setText(
-                "Button pressed "
-                + std::to_string(clickCount)
-                + (clickCount == 1 ? " time." : " times."));
+        auto& zoomIn = panel.addWidget<WidgeCraft::Button>(
+            "Zoom In",
+            "Zoom +");
+        zoomIn.setAnchor(WidgeCraft::Anchor::BottomLeft);
+        zoomIn.setPosition(20.0f, 22.0f);
+        zoomIn.setSize(92.0f, 42.0f);
+        zoomIn.setTextSize(16.0f);
+        zoomIn.setOnClick([&]() {
+            cameraZoom = std::min(cameraZoom * 1.25f, 4.0f);
+            status.setText("2D zoom: " + std::to_string(cameraZoom));
         });
 
-        auto& reset = panel.addWidget<WidgeCraft::Button>(
-            "Reset",
-            "Reset");
-        reset.setAnchor(WidgeCraft::Anchor::BottomLeft);
-        reset.setPosition(176.0f, 30.0f);
-        reset.setSize(112.0f, 46.0f);
-        reset.setTextSize(17.0f);
-        reset.setOnClick([&]() {
-            clickCount = 0;
-            status.setText("Counter reset.");
+        auto& zoomOut = panel.addWidget<WidgeCraft::Button>(
+            "Zoom Out",
+            "Zoom -");
+        zoomOut.setAnchor(WidgeCraft::Anchor::BottomLeft);
+        zoomOut.setPosition(124.0f, 22.0f);
+        zoomOut.setSize(92.0f, 42.0f);
+        zoomOut.setTextSize(16.0f);
+        zoomOut.setOnClick([&]() {
+            cameraZoom = std::max(cameraZoom / 1.25f, 0.25f);
+            status.setText("2D zoom: " + std::to_string(cameraZoom));
         });
 
-        auto& decoration = panel.addWidget<WidgeCraft::Checkbox>(
-            "Decoration",
-            "Show scene decoration",
-            showDecoration);
-        decoration.setAnchor(WidgeCraft::Anchor::BottomRight);
-        decoration.setPosition(24.0f, 40.0f);
-        decoration.setTextSize(16.0f);
-        decoration.setOnChanged([&](bool checked) {
-            showDecoration = checked;
+        auto& threeDToggle = panel.addWidget<WidgeCraft::Checkbox>(
+            "3D Toggle",
+            "Show 3D cubes",
+            show3D);
+        threeDToggle.setAnchor(WidgeCraft::Anchor::BottomRight);
+        threeDToggle.setPosition(20.0f, 31.0f);
+        threeDToggle.setTextSize(15.0f);
+        threeDToggle.setOnChanged([&](bool checked) {
+            show3D = checked;
             status.setText(
-                checked
-                ? "Scene decoration enabled."
-                : "Scene decoration hidden.");
+                checked ? "3D scene enabled." : "3D scene hidden.");
         });
 
         app.setRenderCallback([&](WidgeCraft::WidgeCraft& engine) {
-            if (!showDecoration) {
-                return;
+            const float windowWidth =
+                static_cast<float>(engine.getWindow().getWidth());
+            const float windowHeight =
+                static_cast<float>(engine.getWindow().getHeight());
+
+            modelFrame.setSize(
+                std::max(windowWidth - 56.0f, 40.0f),
+                std::max(windowHeight - 56.0f, 40.0f));
+
+            const WidgeCraft::Rect frameRect = modelFrame.getAbsoluteRect();
+            modelViewport.setScreenRect({
+                frameRect.x + 4.0f,
+                frameRect.y + 4.0f,
+                std::max(frameRect.width - 8.0f, 1.0f),
+                std::max(frameRect.height - 8.0f, 1.0f)
+            });
+            modelViewport.getCamera2D().setZoom(cameraZoom);
+            engine.useModelViewport(modelViewport);
+
+            auto& shapes2D = engine.getShapes2D();
+            auto& shapes3D = engine.getShapes3D();
+            auto& text = engine.getTextRenderer();
+
+            for (int x = -1200; x <= 1200; x += 80) {
+                const bool major = (x % 400) == 0;
+                shapes2D.drawLine(
+                    static_cast<float>(x), -900.0f,
+                    static_cast<float>(x), 900.0f,
+                    major ? 2.0f : 1.0f,
+                    major
+                        ? WidgeCraft::Color{ 0.14f, 0.26f, 0.38f, 0.72f }
+                        : WidgeCraft::Color{ 0.08f, 0.13f, 0.20f, 0.60f });
+            }
+            for (int y = -900; y <= 900; y += 80) {
+                const bool major = (y % 400) == 0;
+                shapes2D.drawLine(
+                    -1200.0f, static_cast<float>(y),
+                    1200.0f, static_cast<float>(y),
+                    major ? 2.0f : 1.0f,
+                    major
+                        ? WidgeCraft::Color{ 0.14f, 0.26f, 0.38f, 0.72f }
+                        : WidgeCraft::Color{ 0.08f, 0.13f, 0.20f, 0.60f });
             }
 
-            auto& shapes = engine.getShapes2D();
-            const float width = static_cast<float>(
-                engine.getWindow().getWidth());
-            const float height = static_cast<float>(
-                engine.getWindow().getHeight());
-
-            sceneViewport.resize(width, height);
-            shapes.setTransform(
-                sceneViewport.getOffset(),
-                sceneViewport.getScale());
-
             WidgeCraft::ShapeStyle2D circleStyle;
-            circleStyle.fillColor = { 0.06f, 0.20f, 0.30f, 0.75f };
-            circleStyle.edgeColor = { 0.25f, 0.68f, 0.92f, 0.9f };
-            circleStyle.edgeThickness = 3.0f;
+            circleStyle.fillColor = { 0.06f, 0.30f, 0.42f, 0.72f };
+            circleStyle.edgeColor = { 0.32f, 0.82f, 1.0f, 1.0f };
+            circleStyle.edgeThickness = 4.0f;
             circleStyle.edgeVisible = true;
-            shapes.drawCircle(
-                { sceneWidth * 0.18f, sceneHeight * 0.74f },
-                92.0f,
-                circleStyle);
+            shapes2D.drawCircle({ -330.0f, -180.0f }, 92.0f, circleStyle);
 
             WidgeCraft::ShapeStyle2D rectangleStyle;
-            rectangleStyle.fillColor = { 0.16f, 0.08f, 0.24f, 0.70f };
-            rectangleStyle.edgeColor = { 0.66f, 0.38f, 0.90f, 0.95f };
+            rectangleStyle.fillColor = { 0.24f, 0.09f, 0.34f, 0.72f };
+            rectangleStyle.edgeColor = { 0.76f, 0.42f, 0.94f, 1.0f };
             rectangleStyle.edgeThickness = 4.0f;
             rectangleStyle.edgeVisible = true;
-            shapes.drawRect(
-                {
-                    sceneWidth * 0.74f,
-                    sceneHeight * 0.18f,
-                    170.0f,
-                    116.0f
-                },
+            shapes2D.drawRect(
+                { 230.0f, -245.0f, 190.0f, 130.0f },
                 rectangleStyle);
 
             WidgeCraft::ShapeStyle2D triangleStyle;
-            triangleStyle.fillColor = { 0.10f, 0.28f, 0.18f, 0.72f };
-            triangleStyle.edgeColor = { 0.35f, 0.84f, 0.56f, 0.95f };
+            triangleStyle.fillColor = { 0.08f, 0.34f, 0.20f, 0.74f };
+            triangleStyle.edgeColor = { 0.38f, 0.92f, 0.58f, 1.0f };
             triangleStyle.edgeThickness = 4.0f;
             triangleStyle.edgeVisible = true;
-            shapes.drawTriangle(
-                { sceneWidth * 0.79f, sceneHeight * 0.78f },
-                { sceneWidth * 0.90f, sceneHeight * 0.58f },
-                { sceneWidth * 0.68f, sceneHeight * 0.58f },
+            shapes2D.drawTriangle(
+                { 315.0f, 260.0f },
+                { 425.0f, 70.0f },
+                { 205.0f, 70.0f },
                 triangleStyle);
+
+            modelViewport.drawWorldText2D(
+                text,
+                "2D world text",
+                { -430.0f, 275.0f },
+                28.0f,
+                { 0.76f, 0.90f, 1.0f, 1.0f });
+
+            if (show3D) {
+                WidgeCraft::ShapeStyle3D cubeStyle;
+                cubeStyle.fillColor = { 0.14f, 0.42f, 0.72f, 0.78f };
+                cubeStyle.edgeColor = { 0.72f, 0.90f, 1.0f, 1.0f };
+                cubeStyle.edgeThickness = 2.0f;
+                cubeStyle.edgeVisible = true;
+
+                shapes3D.drawCube({ -1.7f, 0.0f, 0.0f }, 1.8f, cubeStyle);
+                cubeStyle.fillColor = { 0.64f, 0.25f, 0.18f, 0.78f };
+                shapes3D.drawCube({ 1.2f, 0.5f, -1.0f }, 2.0f, cubeStyle);
+
+                modelViewport.drawLabel3D(
+                    text,
+                    "Cube A",
+                    { -1.7f, 1.15f, 0.0f },
+                    17.0f,
+                    { 0.84f, 0.94f, 1.0f, 1.0f });
+                modelViewport.drawWorldText3D(
+                    text,
+                    "World-sized",
+                    { 1.2f, 1.75f, -1.0f },
+                    0.45f,
+                    { 1.0f, 0.82f, 0.62f, 1.0f });
+            }
         });
 
         app.Run(60);
     } catch (const std::exception& exception) {
-        std::cerr << "WidgeCraft UI sandbox failed: "
-            << exception.what() << '\n';
+        std::cerr << "WidgeCraft viewport sandbox failed: "
+                  << exception.what() << '\n';
         return 1;
     }
 

--- a/src/core/WidgeCraft.cpp
+++ b/src/core/WidgeCraft.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <filesystem>
 #include <thread>
 #include <utility>
@@ -24,6 +25,21 @@ namespace WidgeCraft {
                 std::filesystem::current_path()
                 / "assets/fonts/Roboto-Regular.ttf";
             return localPath.string();
+        }
+
+        Rect clipToFramebuffer(
+            const Rect& rect,
+            int framebufferWidth,
+            int framebufferHeight) {
+
+            return intersect(
+                rect,
+                Rect{
+                    0.0f,
+                    0.0f,
+                    static_cast<float>(std::max(framebufferWidth, 0)),
+                    static_cast<float>(std::max(framebufferHeight, 0))
+                });
         }
     } // namespace
 
@@ -95,6 +111,28 @@ namespace WidgeCraft {
         }
     }
 
+    void WidgeCraft::useModelViewport(
+        const ModelViewport& viewport) {
+
+        m_modelViewportRect = viewport.getScreenRect();
+        m_modelViewportActive =
+            m_modelViewportRect.width > 0.0f
+            && m_modelViewportRect.height > 0.0f;
+
+        if (!m_modelViewportActive) {
+            m_shapes2D.resetTransform();
+            return;
+        }
+
+        viewport.configureRenderers(m_shapes2D, m_shapes3D);
+    }
+
+    void WidgeCraft::clearModelViewport() {
+        m_modelViewportActive = false;
+        m_modelViewportRect = {};
+        m_shapes2D.resetTransform();
+    }
+
     void WidgeCraft::Update() {
         m_textRenderer.setScreenSize(
             m_window.getWidth(),
@@ -112,6 +150,11 @@ namespace WidgeCraft {
     }
 
     void WidgeCraft::Render() {
+        const int framebufferWidth = m_window.getWidth();
+        const int framebufferHeight = m_window.getHeight();
+
+        glViewport(0, 0, framebufferWidth, framebufferHeight);
+        glDisable(GL_SCISSOR_TEST);
         glClearColor(
             m_clearColor.r,
             m_clearColor.g,
@@ -122,6 +165,8 @@ namespace WidgeCraft {
         m_shapes3D.beginFrame();
         m_shapes2D.beginFrame();
         m_textRenderer.beginFrame();
+        m_modelViewportActive = false;
+        m_modelViewportRect = {};
 
         if (m_scene) {
             m_scene->onRender(*this);
@@ -130,13 +175,44 @@ namespace WidgeCraft {
             m_renderCallback(*this);
         }
 
-        // World geometry first, then the transformed 2D scene.
-        m_shapes3D.flush();
-        m_shapes2D.flush();
-        m_textRenderer.flush();
+        if (m_modelViewportActive) {
+            const Rect clipped = clipToFramebuffer(
+                m_modelViewportRect,
+                framebufferWidth,
+                framebufferHeight);
 
-        // Retained UI always uses native client pixels, regardless of any
-        // logical scene transform used by the callback or Scene.
+            const int left = static_cast<int>(std::floor(clipped.x));
+            const int bottom = static_cast<int>(std::floor(clipped.y));
+            const int right = static_cast<int>(std::ceil(clipped.right()));
+            const int top = static_cast<int>(std::ceil(clipped.top()));
+            const int clipWidth = std::max(0, right - left);
+            const int clipHeight = std::max(0, top - bottom);
+
+            glEnable(GL_SCISSOR_TEST);
+            glScissor(left, bottom, clipWidth, clipHeight);
+
+            // 3D uses the model rectangle as its OpenGL viewport. The camera
+            // projection was built from the same aspect ratio.
+            glViewport(left, bottom, clipWidth, clipHeight);
+            m_shapes3D.flush();
+
+            // 2D shapes and text are already transformed into full-framebuffer
+            // coordinates, so only scissoring remains active for these passes.
+            glViewport(0, 0, framebufferWidth, framebufferHeight);
+            m_shapes2D.flush();
+            m_textRenderer.flush();
+
+            glDisable(GL_SCISSOR_TEST);
+        } else {
+            m_shapes3D.flush();
+            m_shapes2D.flush();
+            m_textRenderer.flush();
+        }
+
+        // Retained UI always renders in native framebuffer pixels. Scene
+        // transforms, clipping and the 3D viewport cannot stretch or crop it.
+        glViewport(0, 0, framebufferWidth, framebufferHeight);
+        glDisable(GL_SCISSOR_TEST);
         m_shapes2D.resetTransform();
         m_window.getRootFrame().render(
             m_textRenderer,


### PR DESCRIPTION
## What changed
- adds `Camera2D` with uniform world-to-screen scaling and reversible coordinate conversion
- adds perspective and orthographic `Camera3D` projection with live viewport aspect
- adds `ModelViewport` as the shared 2D/3D model-area abstraction
- adds 2D world text, fixed-pixel 2D labels, fixed-pixel projected 3D labels and world-sized projected 3D text
- adds viewport-local 3D ray generation and world-to-screen projection
- applies the model rectangle as the OpenGL viewport for 3D and as a scissor rectangle for all scene passes
- restores the full framebuffer before retained UI rendering so UI geometry and text remain native-pixel and unstretched
- updates the sandbox to exercise a large clipped 2D map, styled primitives, 3D cubes and both scene-text modes
- documents the new model-viewport workflow

## Rendering behaviour
- resizing a model area changes the amount of 2D world visible rather than distorting objects
- the 3D projection matrix is rebuilt from the model rectangle aspect ratio
- scene geometry and text cannot render outside the model rectangle
- retained UI remains outside scene transforms and clipping

## Compatibility
The older `SceneViewport2D` fixed-canvas helper remains available. Existing primitive and UI APIs are unchanged.

## Validation
The VS2022 Win32 Release workflow must configure and build the engine and sandbox. Final viewport/scissor and resize behaviour still needs a visual run on the Windows/OpenGL target machine.