### PR TITLE
Add scene UI management and interactive physics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.25)
-project(WidgeCraft VERSION 0.4.0 LANGUAGES CXX)
+project(WidgeCraft VERSION 0.6.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -26,6 +26,9 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(glfw)
 
 # ---------------- GLAD ----------------
+# Use the specification bundled with the pinned GLAD release. This keeps clean
+# builds deterministic and avoids a second network download during generation.
+set(GLAD_REPRODUCIBLE ON CACHE BOOL "" FORCE)
 FetchContent_Declare(
     glad
     GIT_REPOSITORY https://github.com/Dav1dde/glad.git
@@ -45,10 +48,15 @@ endfunction()
 set(WIDGECRAFT_ENGINE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/WidgeCraft.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/input/Input.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/physics/Collider.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/physics/PhysicsWorld.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/window/Window.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/ui/Frame.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/ui/Widget.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/ui/UiManager.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/ui/UiScreen.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Scene.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/SceneManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Camera2D.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Camera3D.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/ModelViewport.hpp
@@ -64,9 +72,13 @@ set(WIDGECRAFT_ENGINE_HEADERS
 set(WIDGECRAFT_ENGINE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/WidgeCraft.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/input/Input.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/physics/PhysicsWorld.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/window/Window.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/Frame.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/Widget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/UiManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/UiScreen.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/scene/SceneManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scene/Raycast.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/ShaderProgram.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/primitives/Shapes2D.cpp

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # WidgeCraft
 
-WidgeCraft is a Windows-focused C++17/OpenGL 3.3 engine foundation with retained UI, SDF text, batched 2D primitives, basic 3D primitives, clipped model viewports and ray queries. The supported development target is Visual Studio 2022, Win32, Release.
+WidgeCraft is a Windows-focused C++17/OpenGL 3.3 engine foundation with managed scenes and UI screens, lightweight AABB physics, retained UI, SDF text, batched 2D primitives, basic 3D primitives, independently clipped model viewports and ray queries. The supported development target is Visual Studio 2022, Win32, Release.
 
 ## Project layout
 
 ```text
 include/WidgeCraft/
   input/        Keyboard, mouse and pointer state
+  physics/      Box colliders, bodies, gravity and collision resolution
   window/       Window, framebuffer and client-area ownership
-  ui/           Frames and retained UI widgets
-  scene/        Cameras, model viewports, scene lifecycle and raycasting
+  ui/           UI screens, scene views, frames and retained widgets
+  scene/        Scene management, cameras, model viewports and raycasting
   render/       Shader-program and rendering-pipeline utilities
   primitives/   Maths/types, Shapes2D, Shapes3D and SDF text
 
 src/
   core/         Application loop and subsystem orchestration
   input/        Input implementation
+  physics/      Sub-stepped physics simulation and collision solver
   window/       Window implementation
   ui/           Frame and widget implementation
   scene/        Scene-query implementation
@@ -43,33 +45,35 @@ viewport.getCamera3D().setTarget({ 0.0f, 0.0f, 0.0f });
 viewport.getCamera3D().setPerspective(55.0f);
 
 app.setRenderCallback([&](WidgeCraft::WidgeCraft& engine) {
-    engine.useModelViewport(viewport);
+    engine.renderViewport(viewport, [&](WidgeCraft::WidgeCraft& pass) {
+        pass.getShapes2D().drawCircle(
+            { 0.0f, 0.0f },
+            100.0f,
+            circleStyle);
 
-    engine.getShapes2D().drawCircle(
-        { 0.0f, 0.0f },
-        100.0f,
-        circleStyle);
+        pass.getShapes3D().drawCube(
+            { 0.0f, 0.0f, 0.0f },
+            1.5f,
+            cubeStyle);
 
-    engine.getShapes3D().drawCube(
-        { 0.0f, 0.0f, 0.0f },
-        1.5f,
-        cubeStyle);
+        viewport.drawWorldText2D(
+            pass.getTextRenderer(),
+            "Map label",
+            { 120.0f, 80.0f },
+            24.0f);
 
-    viewport.drawWorldText2D(
-        engine.getTextRenderer(),
-        "Map label",
-        { 120.0f, 80.0f },
-        24.0f);
-
-    viewport.drawLabel3D(
-        engine.getTextRenderer(),
-        "Cube",
-        { 0.0f, 1.0f, 0.0f },
-        16.0f);
+        viewport.drawLabel3D(
+            pass.getTextRenderer(),
+            "Cube",
+            { 0.0f, 1.0f, 0.0f },
+            16.0f);
+    });
 });
 ```
 
-The engine uses the model rectangle as the OpenGL viewport for 3D and as the scissor rectangle for every scene pass. Large maps, terrain and projected labels are clipped at the model boundary. It then restores the full framebuffer before drawing retained UI, so UI frames, shapes and text never inherit scene transforms or stretching.
+Each `renderViewport` call is an independent pass. The engine uses that rectangle as the OpenGL viewport for 3D and as the scissor rectangle for 2D, 3D and text, then flushes the pass before another camera can be selected. Large maps, terrain and projected labels are clipped at the viewport boundary. Geometry and glyphs remain batched within each pass.
+
+The legacy `useModelViewport` API remains supported. Selecting a second viewport now flushes the first one automatically, so different cameras can no longer accidentally share the last viewport state.
 
 ### 2D camera
 
@@ -102,11 +106,90 @@ WidgeCraft::Ray ray = viewport.screenPointToRay3D(
 
 `Shapes3D` supports lines, triangles, quads, boxes and cubes. `ShapeStyle3D` provides fill and edge styling. The 3D edge thickness uses OpenGL line width and is subject to the graphics driver's supported range.
 
+## Physics
+
+`PhysicsWorld` owns static and dynamic bodies with local `BoxCollider` bounds. Dynamic bodies integrate gravity, expose velocity and grounded state, and resolve AABB overlap by the minimum translation axis. The world automatically splits long frames into small steps to reduce tunnelling and lets moving bodies slide along obstacles.
+
+```cpp
+WidgeCraft::PhysicsWorld physics;
+
+physics.createBody(
+    WidgeCraft::PhysicsBodyType::Static,
+    { 0.0f, -0.5f, 0.0f },
+    WidgeCraft::BoxCollider({ 30.0f, 0.5f, 30.0f }));
+
+auto& player = physics.createBody(
+    WidgeCraft::PhysicsBodyType::Dynamic,
+    { 0.0f, 0.9f, 5.0f },
+    WidgeCraft::BoxCollider({ 0.55f, 0.9f, 0.55f }),
+    1);
+
+physics.step(engine.getDeltaTime());
+```
+
+`PhysicsBody::getBounds()` returns the same world-space `AABB` accepted by `raycast`, so picking and collision can share one authoritative bound. This first physics layer intentionally uses axis-aligned boxes and has no rotational dynamics or mesh colliders yet.
+
 ## Scene and UI
 
-`Scene` provides optional attach, detach, update and render hooks. Callback-based update/render code remains supported.
+`SceneManager` stores named `Scene` objects and keeps their state alive while another scene is active. `UiManager` does the same for named `UiScreen` objects. Both provide attach, detach, update and render lifecycles.
 
-The retained UI contains `Frame`, `Label`, `Button` and `Checkbox`. UI rendering is isolated from model-viewport transforms and clipping.
+```cpp
+app.getSceneManager().emplace<LoadingScene>("loading", gameState);
+app.getSceneManager().emplace<WorldScene>("world", gameState);
+app.getUiManager().emplace<CharacterUi>("character", app, gameState);
+app.getUiManager().emplace<CombatUi>("combat", app, gameState);
+
+app.getSceneManager().activate("loading");
+app.getUiManager().activate("character");
+```
+
+Use requests from scene or widget callbacks. They are applied together at the next safe frame boundary, after the current callback has returned.
+
+```cpp
+loadButton.setOnClick([&app]() {
+    app.getSceneManager().request("world");
+    app.getUiManager().request("combat");
+});
+```
+
+### Scene views inside UI
+
+`SceneView` binds a `ModelViewport` to a retained `Frame`. It follows the frame's anchor, size, visibility and clipping hierarchy, renders before the frame, and lets the frame's border and widgets overlay its contents. This is intended for minimaps, model previews, inventory characters and editor panels.
+
+```cpp
+auto& mapFrame = getRootFrame().createChildFrame("Minimap Frame");
+mapFrame.setAnchor(WidgeCraft::Anchor::TopRight);
+mapFrame.setSize(280.0f, 220.0f);
+
+auto& minimap = createSceneView("Minimap", mapFrame);
+minimap.setInset(4.0f);
+minimap.getViewport().getCamera2D().setZoom(8.0f);
+minimap.setRenderCallback([](
+    WidgeCraft::WidgeCraft& engine,
+    const WidgeCraft::SceneView& view) {
+    engine.getShapes2D().drawCircle(
+        playerPosition,
+        1.0f,
+        playerStyle);
+    view.getViewport().drawLabel2D(
+        engine.getTextRenderer(),
+        "Player",
+        playerPosition,
+        14.0f);
+});
+```
+
+Inactive UI screens do not render or process widget input. The retained UI contains `Frame`, `Label`, `Button` and `Checkbox`, and remains isolated from scene transforms and clipping.
+
+## Interactive sandbox controls
+
+After loading the world from the character screen:
+
+- `W`, `A`, `S`, `D` move the gravity-driven player relative to its facing direction.
+- Hold the right mouse button and drag horizontally to turn, or vertically to look up and down.
+- Scroll towards the player to enter first person; the player model is hidden at minimum distance. Scroll out for the chase camera.
+- Left-click an enemy to raycast-select it. Only the selected enemy displays its object ID.
+- Enemy physics bodies block the player and use the same bounds as selection.
 
 ## Generate the Visual Studio solution
 

--- a/include/WidgeCraft/WidgeCraft.hpp
+++ b/include/WidgeCraft/WidgeCraft.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "WidgeCraft/input/Input.hpp"
+#include "WidgeCraft/physics/Collider.hpp"
+#include "WidgeCraft/physics/PhysicsWorld.hpp"
 #include "WidgeCraft/primitives/Shapes2D.hpp"
 #include "WidgeCraft/primitives/Shapes3D.hpp"
 #include "WidgeCraft/primitives/TextRenderer.hpp"
@@ -11,8 +13,11 @@
 #include "WidgeCraft/scene/ModelViewport.hpp"
 #include "WidgeCraft/scene/Raycast.hpp"
 #include "WidgeCraft/scene/Scene.hpp"
+#include "WidgeCraft/scene/SceneManager.hpp"
 #include "WidgeCraft/scene/SceneViewport2D.hpp"
 #include "WidgeCraft/ui/Frame.hpp"
+#include "WidgeCraft/ui/UiManager.hpp"
+#include "WidgeCraft/ui/UiScreen.hpp"
 #include "WidgeCraft/ui/Widget.hpp"
 #include "WidgeCraft/window/Window.hpp"
 
@@ -23,10 +28,17 @@
 
 namespace WidgeCraft {
 
+    struct ViewportRenderOptions {
+        bool clearColor = false;
+        bool clearDepth = true;
+        Color color{ Colors::Black };
+    };
+
     class WidgeCraft {
     public:
         using UpdateCallback = std::function<void(WidgeCraft&)>;
         using RenderCallback = std::function<void(WidgeCraft&)>;
+        using ViewportRenderCallback = std::function<void(WidgeCraft&)>;
 
         WidgeCraft(
             std::string title,
@@ -54,13 +66,28 @@ namespace WidgeCraft {
         }
 
         void setScene(std::unique_ptr<Scene> scene);
-        Scene* getScene() { return m_scene.get(); }
-        const Scene* getScene() const { return m_scene.get(); }
+        Scene* getScene() { return m_sceneManager.getActive(); }
+        const Scene* getScene() const { return m_sceneManager.getActive(); }
 
-        // Selects one clipped model area for the current render frame.
-        // Geometry queued after this call uses the viewport's 2D and 3D cameras.
+        SceneManager& getSceneManager() { return m_sceneManager; }
+        const SceneManager& getSceneManager() const {
+            return m_sceneManager;
+        }
+        UiManager& getUiManager() { return m_uiManager; }
+        const UiManager& getUiManager() const { return m_uiManager; }
+
+        // Selects a clipped model area. Selecting another viewport or clearing
+        // this one flushes the queued geometry with the correct camera and clip.
         void useModelViewport(const ModelViewport& viewport);
         void clearModelViewport();
+
+        // Runs and flushes one independently clipped render pass. Geometry and
+        // scene text remain batched within the pass; multiple passes can safely
+        // use different 2D/3D cameras in the same frame.
+        void renderViewport(
+            const ModelViewport& viewport,
+            const ViewportRenderCallback& callback,
+            const ViewportRenderOptions& options = {});
         bool hasActiveModelViewport() const {
             return m_modelViewportActive;
         }
@@ -97,6 +124,8 @@ namespace WidgeCraft {
 
     private:
         void initializeGraphics();
+        void flushSceneQueues();
+        void restoreFullFramebufferState();
         static std::string resolveFontPath(const std::string& fontPath);
 
         Window m_window;
@@ -106,9 +135,12 @@ namespace WidgeCraft {
         Color m_clearColor{ 0.055f, 0.070f, 0.095f, 1.0f };
         UpdateCallback m_updateCallback;
         RenderCallback m_renderCallback;
-        std::unique_ptr<Scene> m_scene;
+        SceneManager m_sceneManager;
+        UiManager m_uiManager;
         Rect m_modelViewportRect{};
+        ViewportRenderOptions m_modelViewportOptions{};
         bool m_modelViewportActive = false;
+        bool m_viewportCallbackActive = false;
         float m_deltaTime = 0.0f;
         double m_elapsedTime = 0.0;
         int m_targetFrameRate = 60;

--- a/include/WidgeCraft/input/Input.hpp
+++ b/include/WidgeCraft/input/Input.hpp
@@ -6,6 +6,18 @@
 
 namespace WidgeCraft {
 
+    // Values match GLFW's stable public key codes without exposing GLFW in
+    // engine-facing headers.
+    enum class Key : int {
+        Space = 32,
+        A = 65,
+        D = 68,
+        S = 83,
+        W = 87,
+        Escape = 256,
+        LeftShift = 340
+    };
+
     enum class MouseButton : int {
         Left = 0,
         Right = 1,
@@ -22,6 +34,15 @@ namespace WidgeCraft {
         bool keyDown(int key) const;
         bool keyPressed(int key) const;
         bool keyReleased(int key) const;
+        bool keyDown(Key key) const {
+            return keyDown(static_cast<int>(key));
+        }
+        bool keyPressed(Key key) const {
+            return keyPressed(static_cast<int>(key));
+        }
+        bool keyReleased(Key key) const {
+            return keyReleased(static_cast<int>(key));
+        }
 
         bool mouseDown(MouseButton button) const;
         bool mousePressed(MouseButton button) const;

--- a/include/WidgeCraft/physics/Collider.hpp
+++ b/include/WidgeCraft/physics/Collider.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "WidgeCraft/primitives/Types.hpp"
+
+#include <algorithm>
+
+namespace WidgeCraft {
+
+    struct BoxCollider {
+        Vec3 halfExtents{ 0.5f, 0.5f, 0.5f };
+        Vec3 offset{};
+
+        BoxCollider() = default;
+
+        explicit BoxCollider(
+            const Vec3& halfExtentsValue,
+            const Vec3& offsetValue = {})
+            : offset(offsetValue) {
+            setHalfExtents(halfExtentsValue);
+        }
+
+        void setHalfExtents(const Vec3& value) {
+            halfExtents = {
+                std::max(value.x, 0.001f),
+                std::max(value.y, 0.001f),
+                std::max(value.z, 0.001f)
+            };
+        }
+    };
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/physics/PhysicsWorld.hpp
+++ b/include/WidgeCraft/physics/PhysicsWorld.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "WidgeCraft/physics/Collider.hpp"
+#include "WidgeCraft/scene/Raycast.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace WidgeCraft {
+
+    using PhysicsBodyId = std::uint64_t;
+
+    enum class PhysicsBodyType {
+        Static,
+        Dynamic
+    };
+
+    class PhysicsBody {
+    public:
+        PhysicsBodyId getId() const { return m_id; }
+
+        PhysicsBodyType getType() const { return m_type; }
+        void setType(PhysicsBodyType type);
+        bool isStatic() const { return m_type == PhysicsBodyType::Static; }
+        bool isDynamic() const { return m_type == PhysicsBodyType::Dynamic; }
+
+        Vec3 getPosition() const { return m_position; }
+        void setPosition(const Vec3& position) { m_position = position; }
+
+        Vec3 getVelocity() const { return m_velocity; }
+        void setVelocity(const Vec3& velocity) { m_velocity = velocity; }
+
+        float getMass() const { return m_mass; }
+        void setMass(float mass);
+
+        float getGravityScale() const { return m_gravityScale; }
+        void setGravityScale(float scale);
+
+        const BoxCollider& getCollider() const { return m_collider; }
+        void setCollider(const BoxCollider& collider) {
+            m_collider = collider;
+        }
+
+        AABB getBounds() const;
+        bool isGrounded() const { return m_grounded; }
+
+        void setEnabled(bool enabled) { m_enabled = enabled; }
+        bool isEnabled() const { return m_enabled; }
+
+    private:
+        friend class PhysicsWorld;
+
+        PhysicsBody(
+            PhysicsBodyId id,
+            PhysicsBodyType type,
+            const Vec3& position,
+            const BoxCollider& collider);
+
+        float inverseMass() const;
+
+        PhysicsBodyId m_id = 0;
+        PhysicsBodyType m_type = PhysicsBodyType::Static;
+        Vec3 m_position{};
+        Vec3 m_velocity{};
+        BoxCollider m_collider;
+        float m_mass = 1.0f;
+        float m_gravityScale = 1.0f;
+        bool m_grounded = false;
+        bool m_enabled = true;
+    };
+
+    struct PhysicsCollision {
+        PhysicsBodyId firstBody = 0;
+        PhysicsBodyId secondBody = 0;
+        // Points from the second body towards the first body.
+        Vec3 normal{};
+        float penetration = 0.0f;
+    };
+
+    class PhysicsWorld {
+    public:
+        PhysicsBody& createBody(
+            PhysicsBodyType type,
+            const Vec3& position,
+            const BoxCollider& collider = {},
+            PhysicsBodyId requestedId = 0);
+
+        PhysicsBody* findBody(PhysicsBodyId id);
+        const PhysicsBody* findBody(PhysicsBodyId id) const;
+        bool removeBody(PhysicsBodyId id);
+        void clear();
+
+        void setGravity(const Vec3& gravity) { m_gravity = gravity; }
+        Vec3 getGravity() const { return m_gravity; }
+
+        void setMaximumStep(float seconds);
+        float getMaximumStep() const { return m_maximumStep; }
+
+        void setSolverIterations(int iterations);
+        int getSolverIterations() const { return m_solverIterations; }
+
+        void step(float deltaTime);
+
+        const std::vector<std::unique_ptr<PhysicsBody>>& getBodies() const {
+            return m_bodies;
+        }
+        const std::vector<PhysicsCollision>& getCollisions() const {
+            return m_collisions;
+        }
+
+    private:
+        void integrate(float deltaTime);
+        void solveCollisions();
+        void recordCollision(
+            const PhysicsBody& first,
+            const PhysicsBody& second,
+            const Vec3& normal,
+            float penetration);
+        PhysicsBodyId allocateId();
+
+        Vec3 m_gravity{ 0.0f, -18.0f, 0.0f };
+        std::vector<std::unique_ptr<PhysicsBody>> m_bodies;
+        std::vector<PhysicsCollision> m_collisions;
+        PhysicsBodyId m_nextId = 1;
+        float m_maximumStep = 1.0f / 120.0f;
+        int m_solverIterations = 4;
+    };
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/primitives/TextRenderer.hpp
+++ b/include/WidgeCraft/primitives/TextRenderer.hpp
@@ -15,7 +15,7 @@ namespace WidgeCraft {
 
     class TextRenderer {
     public:
-        using Color = WidgeCraft::Color;
+        using Color = ::WidgeCraft::Color;
 
         struct TextBounds {
             float minX = 0.0f;

--- a/include/WidgeCraft/scene/SceneManager.hpp
+++ b/include/WidgeCraft/scene/SceneManager.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "WidgeCraft/scene/Scene.hpp"
+
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+namespace WidgeCraft {
+
+    class WidgeCraft;
+
+    class SceneManager {
+    public:
+        explicit SceneManager(WidgeCraft& app);
+        ~SceneManager() = default;
+
+        SceneManager(const SceneManager&) = delete;
+        SceneManager& operator=(const SceneManager&) = delete;
+
+        Scene& add(std::string name, std::unique_ptr<Scene> scene);
+
+        template <typename T, typename... Args>
+        T& emplace(std::string name, Args&&... args);
+
+        Scene* find(const std::string& name);
+        const Scene* find(const std::string& name) const;
+        bool contains(const std::string& name) const;
+        bool remove(const std::string& name);
+
+        // activate() is immediate outside a scene callback. During update or
+        // render it is automatically deferred to the next frame boundary.
+        bool activate(const std::string& name);
+        void clearActive();
+
+        // Requests are the safe choice from scenes and UI callbacks. Scene and
+        // UI manager requests are both applied before the next update.
+        bool request(const std::string& name);
+        void requestClear();
+        bool hasPendingChange() const { return m_pendingName.has_value(); }
+
+        Scene* getActive() { return m_active; }
+        const Scene* getActive() const { return m_active; }
+        const std::string& getActiveName() const { return m_activeName; }
+
+    private:
+        friend class WidgeCraft;
+
+        void setTransient(std::unique_ptr<Scene> scene);
+        void applyPending();
+        void update(float deltaTime);
+        void render();
+        void shutdown();
+        void activateNow(Scene* scene, std::string name);
+
+        WidgeCraft& m_app;
+        std::unordered_map<std::string, std::unique_ptr<Scene>> m_scenes;
+        std::unique_ptr<Scene> m_transient;
+        Scene* m_active = nullptr;
+        std::string m_activeName;
+        std::optional<std::string> m_pendingName;
+        bool m_dispatching = false;
+    };
+
+    template <typename T, typename... Args>
+    T& SceneManager::emplace(std::string name, Args&&... args) {
+        static_assert(
+            std::is_base_of_v<Scene, T>,
+            "SceneManager::emplace requires a Scene-derived type");
+        auto scene = std::make_unique<T>(std::forward<Args>(args)...);
+        T& reference = *scene;
+        add(std::move(name), std::move(scene));
+        return reference;
+    }
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/ui/Frame.hpp
+++ b/include/WidgeCraft/ui/Frame.hpp
@@ -46,6 +46,10 @@ namespace WidgeCraft {
 
         void setVisible(bool visible);
         bool isVisible() const { return m_visible; }
+        bool isVisibleInHierarchy() const {
+            return m_visible
+                && (!m_parent || m_parent->isVisibleInHierarchy());
+        }
 
         void setBackgroundVisible(bool visible) { m_showBackground = visible; }
         bool isBackgroundVisible() const { return m_showBackground; }
@@ -74,6 +78,7 @@ namespace WidgeCraft {
 
         Position getAbsolutePosition() const;
         Rect getAbsoluteRect() const;
+        Rect getVisibleRect() const;
 
         Frame& createChildFrame(const std::string& name);
         Frame* findChildFrame(const std::string& name);

--- a/include/WidgeCraft/ui/UiManager.hpp
+++ b/include/WidgeCraft/ui/UiManager.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "WidgeCraft/ui/UiScreen.hpp"
+
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+namespace WidgeCraft {
+
+    class WidgeCraft;
+
+    class UiManager {
+    public:
+        explicit UiManager(WidgeCraft& app);
+        ~UiManager() = default;
+
+        UiManager(const UiManager&) = delete;
+        UiManager& operator=(const UiManager&) = delete;
+
+        UiScreen& add(std::string name, std::unique_ptr<UiScreen> screen);
+
+        template <typename T, typename... Args>
+        T& emplace(std::string name, Args&&... args);
+
+        UiScreen* find(const std::string& name);
+        const UiScreen* find(const std::string& name) const;
+        bool contains(const std::string& name) const;
+        bool remove(const std::string& name);
+
+        // activate() is immediate outside a UI callback. During update or
+        // rendering it is automatically deferred to the next frame boundary.
+        bool activate(const std::string& name);
+        void clearActive();
+        bool request(const std::string& name);
+        void requestClear();
+        bool hasPendingChange() const { return m_pendingName.has_value(); }
+
+        UiScreen* getActive() { return m_active; }
+        const UiScreen* getActive() const { return m_active; }
+        const std::string& getActiveName() const { return m_activeName; }
+
+    private:
+        friend class WidgeCraft;
+
+        void applyPending();
+        void update(float deltaTime);
+        void renderSceneViews();
+        void renderUi();
+        void shutdown();
+        void activateNow(UiScreen* screen, std::string name);
+        void synchronizeRoot(UiScreen& screen);
+
+        WidgeCraft& m_app;
+        std::unordered_map<std::string, std::unique_ptr<UiScreen>> m_screens;
+        UiScreen* m_active = nullptr;
+        std::string m_activeName;
+        std::optional<std::string> m_pendingName;
+        bool m_dispatching = false;
+    };
+
+    template <typename T, typename... Args>
+    T& UiManager::emplace(std::string name, Args&&... args) {
+        static_assert(
+            std::is_base_of_v<UiScreen, T>,
+            "UiManager::emplace requires a UiScreen-derived type");
+        auto screen = std::make_unique<T>(std::forward<Args>(args)...);
+        T& reference = *screen;
+        add(std::move(name), std::move(screen));
+        return reference;
+    }
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/ui/UiScreen.hpp
+++ b/include/WidgeCraft/ui/UiScreen.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "WidgeCraft/primitives/Types.hpp"
+#include "WidgeCraft/scene/ModelViewport.hpp"
+#include "WidgeCraft/ui/Frame.hpp"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace WidgeCraft {
+
+    class WidgeCraft;
+
+    // A scene render pass whose rectangle follows a retained UI frame. The
+    // frame itself is still rendered afterwards, so its border and widgets
+    // naturally overlay the scene content.
+    class SceneView {
+    public:
+        using RenderCallback =
+            std::function<void(WidgeCraft&, const SceneView&)>;
+
+        SceneView(std::string name, Frame& frame);
+
+        const std::string& getName() const { return m_name; }
+        Frame& getFrame() { return *m_frame; }
+        const Frame& getFrame() const { return *m_frame; }
+
+        ModelViewport& getViewport() { return m_viewport; }
+        const ModelViewport& getViewport() const { return m_viewport; }
+
+        void setVisible(bool visible) { m_visible = visible; }
+        bool isVisible() const { return m_visible; }
+
+        void setInset(float inset);
+        void setInsets(float left, float bottom, float right, float top);
+
+        void setClearColor(Color color) {
+            m_clearColor = color;
+            m_clearsColor = true;
+        }
+        void setClearColorEnabled(bool enabled) { m_clearsColor = enabled; }
+        bool clearsColor() const { return m_clearsColor; }
+        Color getClearColor() const { return m_clearColor; }
+
+        void setRenderCallback(RenderCallback callback) {
+            m_renderCallback = std::move(callback);
+        }
+
+    private:
+        friend class UiScreen;
+
+        void render(WidgeCraft& app);
+
+        std::string m_name;
+        Frame* m_frame = nullptr;
+        ModelViewport m_viewport;
+        RenderCallback m_renderCallback;
+        Color m_clearColor{ 0.025f, 0.035f, 0.055f, 1.0f };
+        float m_leftInset = 0.0f;
+        float m_bottomInset = 0.0f;
+        float m_rightInset = 0.0f;
+        float m_topInset = 0.0f;
+        bool m_visible = true;
+        bool m_clearsColor = true;
+    };
+
+    class UiScreen {
+    public:
+        explicit UiScreen(std::string name);
+        virtual ~UiScreen() = default;
+
+        UiScreen(const UiScreen&) = delete;
+        UiScreen& operator=(const UiScreen&) = delete;
+
+        const std::string& getName() const { return m_name; }
+        Frame& getRootFrame() { return m_rootFrame; }
+        const Frame& getRootFrame() const { return m_rootFrame; }
+
+        SceneView& createSceneView(
+            const std::string& name,
+            Frame& frame);
+        SceneView* findSceneView(const std::string& name);
+        const SceneView* findSceneView(const std::string& name) const;
+        bool removeSceneView(const std::string& name);
+
+        virtual void onAttach(WidgeCraft& app) { (void)app; }
+        virtual void onDetach(WidgeCraft& app) { (void)app; }
+        virtual void onUpdate(WidgeCraft& app, float deltaTime) {
+            (void)app;
+            (void)deltaTime;
+        }
+        virtual void onRender(WidgeCraft& app) { (void)app; }
+
+    private:
+        friend class UiManager;
+
+        void setScreenSize(float width, float height);
+        void renderSceneViews(WidgeCraft& app);
+
+        std::string m_name;
+        Frame m_rootFrame;
+        std::vector<std::unique_ptr<SceneView>> m_sceneViews;
+    };
+
+} // namespace WidgeCraft

--- a/sandbox/UiDemo.cpp
+++ b/sandbox/UiDemo.cpp
@@ -1,219 +1,767 @@
 #include "WidgeCraft/WidgeCraft.hpp"
 
 #include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
 #include <exception>
 #include <iostream>
+#include <limits>
+#include <stdexcept>
 #include <string>
+#include <utility>
+#include <vector>
 
-int main() {
+namespace {
+
+    constexpr const char* CharacterSceneName = "character-select";
+    constexpr const char* WorldSceneName = "world";
+    constexpr const char* CharacterUiName = "character-select";
+    constexpr const char* CombatUiName = "combat";
+
+    struct DemoState {
+        int character = 0;
+        WidgeCraft::Vec3 playerPosition{ 0.0f, 0.9f, 5.0f };
+        WidgeCraft::Vec2 playerMapPosition{};
+        float playerYaw = 0.0f;
+        float cameraPitch = -0.24f;
+        float cameraDistance = 8.0f;
+        WidgeCraft::PhysicsBodyId selectedEnemyId = 0;
+        bool playerGrounded = false;
+    };
+
+    struct EnemySpawn {
+        WidgeCraft::PhysicsBodyId id = 0;
+        WidgeCraft::Vec3 position{};
+        WidgeCraft::Vec3 halfExtents{};
+    };
+
+    const std::array<EnemySpawn, 3> EnemySpawns{
+        EnemySpawn{
+            1001,
+            { -3.2f, 0.9f, -2.5f },
+            { 0.9f, 0.9f, 0.9f }
+        },
+        EnemySpawn{
+            1002,
+            { 4.0f, 0.65f, 2.0f },
+            { 0.65f, 0.65f, 0.65f }
+        },
+        EnemySpawn{
+            1003,
+            { 1.0f, 1.1f, -7.0f },
+            { 1.1f, 1.1f, 1.1f }
+        }
+    };
+
+    void drawSelectionBackdrop(
+        WidgeCraft::WidgeCraft& app,
+        const DemoState& state) {
+
+        auto& shapes = app.getShapes2D();
+        auto& text = app.getTextRenderer();
+
+        for (int x = -900; x <= 900; x += 60) {
+            shapes.drawLine(
+                static_cast<float>(x),
+                -600.0f,
+                static_cast<float>(x),
+                600.0f,
+                1.0f,
+                { 0.08f, 0.13f, 0.20f, 0.55f });
+        }
+        for (int y = -600; y <= 600; y += 60) {
+            shapes.drawLine(
+                -900.0f,
+                static_cast<float>(y),
+                900.0f,
+                static_cast<float>(y),
+                1.0f,
+                { 0.08f, 0.13f, 0.20f, 0.55f });
+        }
+
+        WidgeCraft::ShapeStyle2D portrait;
+        portrait.fillColor = state.character == 0
+            ? WidgeCraft::Color{ 0.10f, 0.34f, 0.58f, 0.92f }
+            : WidgeCraft::Color{ 0.13f, 0.48f, 0.30f, 0.92f };
+        portrait.edgeColor = state.character == 0
+            ? WidgeCraft::Color{ 0.48f, 0.82f, 1.0f, 1.0f }
+            : WidgeCraft::Color{ 0.48f, 1.0f, 0.68f, 1.0f };
+        portrait.edgeThickness = 5.0f;
+        portrait.edgeVisible = true;
+
+        const float portraitX = state.character == 0 ? -360.0f : 360.0f;
+        shapes.drawCircle({ portraitX, 15.0f }, 135.0f, portrait);
+        shapes.drawFilledCircle(
+            portraitX,
+            68.0f,
+            42.0f,
+            { 0.78f, 0.84f, 0.88f, 1.0f });
+        shapes.drawFilledRect(
+            portraitX - 68.0f,
+            -78.0f,
+            136.0f,
+            102.0f,
+            { 0.20f, 0.24f, 0.31f, 1.0f });
+
+        text.renderTextCentered(
+            state.character == 0 ? "Knight" : "Ranger",
+            portraitX,
+            -160.0f,
+            27.0f,
+            { 0.82f, 0.93f, 1.0f, 1.0f });
+    }
+
+    class CharacterSelectScene final : public WidgeCraft::Scene {
+    public:
+        explicit CharacterSelectScene(DemoState& state)
+            : m_state(state) {
+            m_viewport.getCamera2D().setPosition({ 0.0f, 0.0f });
+        }
+
+        void onRender(WidgeCraft::WidgeCraft& app) override {
+            const float width = static_cast<float>(app.getWindow().getWidth());
+            const float height = static_cast<float>(app.getWindow().getHeight());
+            m_viewport.setScreenRect({ 0.0f, 0.0f, width, height });
+            m_viewport.getCamera2D().setZoom(std::max(
+                0.45f,
+                std::min(width / 1100.0f, height / 720.0f)));
+
+            WidgeCraft::ViewportRenderOptions options;
+            options.clearColor = true;
+            options.color = { 0.020f, 0.030f, 0.050f, 1.0f };
+            app.renderViewport(
+                m_viewport,
+                [this](WidgeCraft::WidgeCraft& engine) {
+                    drawSelectionBackdrop(engine, m_state);
+                },
+                options);
+        }
+
+    private:
+        DemoState& m_state;
+        WidgeCraft::ModelViewport m_viewport;
+    };
+
+    class WorldScene final : public WidgeCraft::Scene {
+    public:
+        explicit WorldScene(DemoState& state)
+            : m_state(state) {
+            m_physics.setGravity({ 0.0f, -18.0f, 0.0f });
+            m_physics.createBody(
+                WidgeCraft::PhysicsBodyType::Static,
+                { 0.0f, -0.5f, 0.0f },
+                WidgeCraft::BoxCollider(
+                    WidgeCraft::Vec3{ 30.0f, 0.5f, 30.0f }),
+                9000);
+
+            m_player = &m_physics.createBody(
+                WidgeCraft::PhysicsBodyType::Dynamic,
+                m_state.playerPosition,
+                WidgeCraft::BoxCollider(
+                    WidgeCraft::Vec3{ 0.55f, 0.9f, 0.55f }),
+                1);
+            m_player->setMass(1.0f);
+
+            for (const EnemySpawn& spawn : EnemySpawns) {
+                WidgeCraft::PhysicsBody& body = m_physics.createBody(
+                    WidgeCraft::PhysicsBodyType::Static,
+                    spawn.position,
+                    WidgeCraft::BoxCollider(spawn.halfExtents),
+                    spawn.id);
+                m_enemies.push_back({ &body, spawn.halfExtents });
+            }
+
+            auto& camera = m_viewport.getCamera3D();
+            camera.setPerspective(52.0f, 0.1f, 250.0f);
+            updateCamera();
+        }
+
+        void onUpdate(
+            WidgeCraft::WidgeCraft& app,
+            float deltaTime) override {
+
+            setViewportToWindow(app);
+            auto& input = app.getInput();
+
+            m_state.cameraDistance = std::clamp(
+                m_state.cameraDistance
+                    - input.scrollDelta().y * 1.25f,
+                MinimumCameraDistance,
+                MaximumCameraDistance);
+
+            if (input.mouseDown(WidgeCraft::MouseButton::Right)) {
+                const WidgeCraft::Vec2 mouseDelta = input.mouseDelta();
+                m_state.playerYaw += mouseDelta.x * LookSensitivity;
+                m_state.cameraPitch = std::clamp(
+                    m_state.cameraPitch
+                        + mouseDelta.y * LookSensitivity,
+                    MinimumCameraPitch,
+                    MaximumCameraPitch);
+            }
+
+            const WidgeCraft::Vec3 forward = horizontalForward();
+            const WidgeCraft::Vec3 right{
+                std::cos(m_state.playerYaw),
+                0.0f,
+                std::sin(m_state.playerYaw)
+            };
+            WidgeCraft::Vec3 movement{};
+            if (input.keyDown(WidgeCraft::Key::W)) {
+                movement += forward;
+            }
+            if (input.keyDown(WidgeCraft::Key::S)) {
+                movement -= forward;
+            }
+            if (input.keyDown(WidgeCraft::Key::D)) {
+                movement += right;
+            }
+            if (input.keyDown(WidgeCraft::Key::A)) {
+                movement -= right;
+            }
+            if (WidgeCraft::lengthSquared(movement) > 1.0f) {
+                movement = WidgeCraft::normalized(movement);
+            }
+
+            WidgeCraft::Vec3 velocity = m_player->getVelocity();
+            velocity.x = movement.x * PlayerSpeed;
+            velocity.z = movement.z * PlayerSpeed;
+            m_player->setVelocity(velocity);
+
+            m_physics.step(deltaTime);
+            m_state.playerPosition = m_player->getPosition();
+            m_state.playerMapPosition = {
+                m_state.playerPosition.x,
+                m_state.playerPosition.z
+            };
+            m_state.playerGrounded = m_player->isGrounded();
+
+            updateCamera();
+            if (input.mousePressed(WidgeCraft::MouseButton::Left)
+                && !input.mouseDown(WidgeCraft::MouseButton::Right)
+                && m_viewport.contains(input.mousePosition())) {
+                selectEnemyAt(input.mousePosition());
+            }
+        }
+
+        void onRender(WidgeCraft::WidgeCraft& app) override {
+            setViewportToWindow(app);
+            updateCamera();
+
+            WidgeCraft::ViewportRenderOptions options;
+            options.clearColor = true;
+            options.color = { 0.018f, 0.028f, 0.040f, 1.0f };
+            app.renderViewport(
+                m_viewport,
+                [this](WidgeCraft::WidgeCraft& engine) {
+                    renderWorld(engine);
+                },
+                options);
+        }
+
+    private:
+        struct Enemy {
+            WidgeCraft::PhysicsBody* body = nullptr;
+            WidgeCraft::Vec3 halfExtents{};
+        };
+
+        static constexpr float PlayerSpeed = 5.0f;
+        static constexpr float LookSensitivity = 0.006f;
+        static constexpr float MinimumCameraDistance = 0.0f;
+        static constexpr float MaximumCameraDistance = 11.0f;
+        static constexpr float FirstPersonThreshold = 0.2f;
+        static constexpr float MinimumCameraPitch = -1.05f;
+        static constexpr float MaximumCameraPitch = 0.78f;
+
+        void setViewportToWindow(WidgeCraft::WidgeCraft& app) {
+            m_viewport.setScreenRect({
+                0.0f,
+                0.0f,
+                static_cast<float>(app.getWindow().getWidth()),
+                static_cast<float>(app.getWindow().getHeight())
+            });
+        }
+
+        WidgeCraft::Vec3 horizontalForward() const {
+            return {
+                std::sin(m_state.playerYaw),
+                0.0f,
+                -std::cos(m_state.playerYaw)
+            };
+        }
+
+        WidgeCraft::Vec3 viewForward() const {
+            const float pitchScale = std::cos(m_state.cameraPitch);
+            return WidgeCraft::normalized({
+                pitchScale * std::sin(m_state.playerYaw),
+                std::sin(m_state.cameraPitch),
+                -pitchScale * std::cos(m_state.playerYaw)
+            });
+        }
+
+        void updateCamera() {
+            const WidgeCraft::Vec3 eye =
+                m_player->getPosition()
+                + WidgeCraft::Vec3{ 0.0f, 0.68f, 0.0f };
+            const WidgeCraft::Vec3 forward = viewForward();
+            auto& camera = m_viewport.getCamera3D();
+            WidgeCraft::Vec3 cameraPosition =
+                eye - forward * m_state.cameraDistance;
+            if (m_state.cameraDistance > FirstPersonThreshold) {
+                // The demo world uses a flat ground plane. Keep the orbit
+                // camera above it when looking sharply upwards.
+                cameraPosition.y = std::max(cameraPosition.y, 0.2f);
+            }
+            camera.setPosition(cameraPosition);
+            camera.setTarget(
+                m_state.cameraDistance <= FirstPersonThreshold
+                    ? eye + forward
+                    : eye);
+        }
+
+        void selectEnemyAt(const WidgeCraft::Vec2& screenPosition) {
+            const WidgeCraft::Ray ray =
+                m_viewport.screenPointToRay3D(screenPosition);
+            float nearestDistance = std::numeric_limits<float>::max();
+            WidgeCraft::PhysicsBodyId nearestId = 0;
+            for (const Enemy& enemy : m_enemies) {
+                if (!enemy.body) {
+                    continue;
+                }
+                WidgeCraft::RayHit hit;
+                if (WidgeCraft::raycast(
+                        ray,
+                        enemy.body->getBounds(),
+                        hit)
+                    && hit.distance < nearestDistance) {
+                    nearestDistance = hit.distance;
+                    nearestId = enemy.body->getId();
+                }
+            }
+            m_state.selectedEnemyId = nearestId;
+        }
+
+        void renderWorld(WidgeCraft::WidgeCraft& app) const {
+            auto& shapes = app.getShapes3D();
+            for (int coordinate = -20; coordinate <= 20; ++coordinate) {
+                const bool major = coordinate == 0;
+                const WidgeCraft::Color color = major
+                    ? WidgeCraft::Color{ 0.28f, 0.52f, 0.68f, 0.9f }
+                    : WidgeCraft::Color{ 0.10f, 0.18f, 0.24f, 0.72f };
+                shapes.drawLine(
+                    { static_cast<float>(coordinate), 0.01f, -20.0f },
+                    { static_cast<float>(coordinate), 0.01f, 20.0f },
+                    major ? 2.0f : 1.0f,
+                    color);
+                shapes.drawLine(
+                    { -20.0f, 0.01f, static_cast<float>(coordinate) },
+                    { 20.0f, 0.01f, static_cast<float>(coordinate) },
+                    major ? 2.0f : 1.0f,
+                    color);
+            }
+
+            if (m_state.cameraDistance > FirstPersonThreshold) {
+                WidgeCraft::ShapeStyle3D playerStyle;
+                playerStyle.fillColor = { 0.12f, 0.48f, 0.82f, 1.0f };
+                playerStyle.edgeColor = { 0.72f, 0.92f, 1.0f, 1.0f };
+                playerStyle.edgeThickness = 2.0f;
+                playerStyle.edgeVisible = true;
+                const WidgeCraft::AABB bounds = m_player->getBounds();
+                shapes.drawBox(
+                    bounds.minimum,
+                    bounds.maximum,
+                    playerStyle);
+
+                const WidgeCraft::Vec3 headingStart =
+                    m_player->getPosition()
+                    + WidgeCraft::Vec3{ 0.0f, 0.75f, 0.0f };
+                shapes.drawLine(
+                    headingStart,
+                    headingStart + horizontalForward() * 1.35f,
+                    3.0f,
+                    { 0.55f, 0.92f, 1.0f, 1.0f });
+            }
+
+            for (const Enemy& enemy : m_enemies) {
+                if (!enemy.body) {
+                    continue;
+                }
+                const bool selected =
+                    enemy.body->getId() == m_state.selectedEnemyId;
+                WidgeCraft::ShapeStyle3D enemyStyle;
+                enemyStyle.fillColor = selected
+                    ? WidgeCraft::Color{ 0.78f, 0.34f, 0.10f, 1.0f }
+                    : WidgeCraft::Color{ 0.68f, 0.16f, 0.13f, 1.0f };
+                enemyStyle.edgeColor = selected
+                    ? WidgeCraft::Color{ 1.0f, 0.92f, 0.32f, 1.0f }
+                    : WidgeCraft::Color{ 1.0f, 0.64f, 0.48f, 1.0f };
+                enemyStyle.edgeThickness = selected ? 4.0f : 2.0f;
+                enemyStyle.edgeVisible = true;
+                const WidgeCraft::AABB bounds = enemy.body->getBounds();
+                shapes.drawBox(
+                    bounds.minimum,
+                    bounds.maximum,
+                    enemyStyle);
+
+                if (selected) {
+                    m_viewport.drawLabel3D(
+                        app.getTextRenderer(),
+                        "Object ID: "
+                            + std::to_string(enemy.body->getId()),
+                        enemy.body->getPosition()
+                            + WidgeCraft::Vec3{
+                                0.0f,
+                                enemy.halfExtents.y + 0.45f,
+                                0.0f
+                            },
+                        19.0f,
+                        { 1.0f, 0.92f, 0.42f, 1.0f });
+                }
+            }
+        }
+
+        DemoState& m_state;
+        WidgeCraft::ModelViewport m_viewport;
+        WidgeCraft::PhysicsWorld m_physics;
+        WidgeCraft::PhysicsBody* m_player = nullptr;
+        std::vector<Enemy> m_enemies;
+    };
+
+    class CharacterSelectUi final : public WidgeCraft::UiScreen {
+    public:
+        CharacterSelectUi(
+            WidgeCraft::WidgeCraft& app,
+            DemoState& state)
+            : UiScreen("Character Select UI")
+            , m_state(state) {
+
+            auto& panel = getRootFrame().createChildFrame("Character Panel");
+            panel.setAnchor(WidgeCraft::Anchor::Center);
+            panel.setSize(430.0f, 330.0f);
+            panel.setBackgroundColor({ 0.045f, 0.065f, 0.095f, 0.96f });
+            panel.setBorderVisible(true);
+            panel.setBorderColor({ 0.30f, 0.55f, 0.78f, 1.0f });
+            panel.setBorderThickness(2.0f);
+
+            auto& title = panel.addWidget<WidgeCraft::Label>(
+                "Title",
+                "Choose your character");
+            title.setAnchor(WidgeCraft::Anchor::TopCenter);
+            title.setPosition(0.0f, 24.0f);
+            title.setTextSize(31.0f);
+            title.setColor({ 0.78f, 0.92f, 1.0f, 1.0f });
+
+            m_status = &panel.addWidget<WidgeCraft::Label>(
+                "Selection",
+                "Selected: Knight");
+            m_status->setAnchor(WidgeCraft::Anchor::TopCenter);
+            m_status->setPosition(0.0f, 82.0f);
+            m_status->setTextSize(18.0f);
+            m_status->setColor({ 0.70f, 0.82f, 0.92f, 1.0f });
+
+            auto& knight = panel.addWidget<WidgeCraft::Button>(
+                "Knight",
+                "Knight");
+            knight.setAnchor(WidgeCraft::Anchor::CenterLeft);
+            knight.setPosition(38.0f, 14.0f);
+            knight.setSize(158.0f, 52.0f);
+            knight.setTextSize(18.0f);
+            knight.setOnClick([this]() {
+                m_state.character = 0;
+                m_status->setText("Selected: Knight");
+            });
+
+            auto& ranger = panel.addWidget<WidgeCraft::Button>(
+                "Ranger",
+                "Ranger");
+            ranger.setAnchor(WidgeCraft::Anchor::CenterRight);
+            ranger.setPosition(38.0f, 14.0f);
+            ranger.setSize(158.0f, 52.0f);
+            ranger.setTextSize(18.0f);
+            ranger.setOnClick([this]() {
+                m_state.character = 1;
+                m_status->setText("Selected: Ranger");
+            });
+
+            auto& load = panel.addWidget<WidgeCraft::Button>(
+                "Load World",
+                "Load world");
+            load.setAnchor(WidgeCraft::Anchor::BottomCenter);
+            load.setPosition(0.0f, 36.0f);
+            load.setSize(250.0f, 58.0f);
+            load.setTextSize(20.0f);
+            load.setBackgroundColor({ 0.10f, 0.38f, 0.58f, 1.0f });
+            load.setHoverColor({ 0.14f, 0.50f, 0.72f, 1.0f });
+            load.setOnClick([&app]() {
+                app.getSceneManager().request(WorldSceneName);
+                app.getUiManager().request(CombatUiName);
+            });
+        }
+
+    private:
+        DemoState& m_state;
+        WidgeCraft::Label* m_status = nullptr;
+    };
+
+    class CombatUi final : public WidgeCraft::UiScreen {
+    public:
+        CombatUi(
+            WidgeCraft::WidgeCraft& app,
+            DemoState& state)
+            : UiScreen("Combat UI")
+            , m_state(state) {
+
+            auto& root = getRootFrame();
+
+            auto& statusPanel = root.createChildFrame("Status Panel");
+            statusPanel.setAnchor(WidgeCraft::Anchor::TopLeft);
+            statusPanel.setPosition(24.0f, 24.0f);
+            statusPanel.setSize(390.0f, 150.0f);
+            statusPanel.setBackgroundColor({ 0.040f, 0.055f, 0.078f, 0.94f });
+            statusPanel.setBorderVisible(true);
+            statusPanel.setBorderColor({ 0.25f, 0.48f, 0.68f, 1.0f });
+            statusPanel.setBorderThickness(2.0f);
+
+            auto& title = statusPanel.addWidget<WidgeCraft::Label>(
+                "Mode",
+                "Interactive world");
+            title.setAnchor(WidgeCraft::Anchor::TopLeft);
+            title.setPosition(18.0f, 14.0f);
+            title.setTextSize(22.0f);
+            title.setColor({ 0.75f, 0.91f, 1.0f, 1.0f });
+
+            auto& movementHelp = statusPanel.addWidget<WidgeCraft::Label>(
+                "Movement Help",
+                "WASD move  |  Right-drag turn and look");
+            movementHelp.setAnchor(WidgeCraft::Anchor::TopLeft);
+            movementHelp.setPosition(18.0f, 50.0f);
+            movementHelp.setTextSize(14.0f);
+            movementHelp.setColor({ 0.70f, 0.80f, 0.90f, 1.0f });
+
+            auto& selectionHelp = statusPanel.addWidget<WidgeCraft::Label>(
+                "Selection Help",
+                "Wheel zoom  |  Left-click an enemy");
+            selectionHelp.setAnchor(WidgeCraft::Anchor::TopLeft);
+            selectionHelp.setPosition(18.0f, 73.0f);
+            selectionHelp.setTextSize(14.0f);
+            selectionHelp.setColor({ 0.70f, 0.80f, 0.90f, 1.0f });
+
+            m_worldStatus = &statusPanel.addWidget<WidgeCraft::Label>(
+                "World Status",
+                "Camera 8.0  |  Grounded");
+            m_worldStatus->setAnchor(WidgeCraft::Anchor::BottomLeft);
+            m_worldStatus->setPosition(18.0f, 16.0f);
+            m_worldStatus->setTextSize(15.0f);
+            m_worldStatus->setColor({ 0.55f, 0.94f, 0.64f, 1.0f });
+
+            m_minimapFrame = &root.createChildFrame("Minimap Frame");
+            m_minimapFrame->setAnchor(WidgeCraft::Anchor::TopRight);
+            m_minimapFrame->setPosition(24.0f, 24.0f);
+            m_minimapFrame->setSize(270.0f, 220.0f);
+            m_minimapFrame->setBackgroundVisible(false);
+            m_minimapFrame->setBorderVisible(true);
+            m_minimapFrame->setBorderColor({ 0.45f, 0.78f, 0.94f, 1.0f });
+            m_minimapFrame->setBorderThickness(3.0f);
+
+            auto& mapTitle = m_minimapFrame->addWidget<WidgeCraft::Label>(
+                "Map Title",
+                "MINIMAP");
+            mapTitle.setAnchor(WidgeCraft::Anchor::TopCenter);
+            mapTitle.setPosition(0.0f, 10.0f);
+            mapTitle.setTextSize(15.0f);
+            mapTitle.setColor({ 0.78f, 0.92f, 1.0f, 1.0f });
+
+            m_minimap = &createSceneView("Minimap", *m_minimapFrame);
+            m_minimap->setInsets(4.0f, 4.0f, 4.0f, 34.0f);
+            m_minimap->setClearColor({ 0.018f, 0.052f, 0.065f, 1.0f });
+            m_minimap->getViewport().getCamera2D().setZoom(7.0f);
+            m_minimap->setRenderCallback(
+                [this](
+                    WidgeCraft::WidgeCraft& engine,
+                    const WidgeCraft::SceneView& view) {
+                    renderMinimap(engine, view);
+                });
+
+            auto& controls = root.createChildFrame("Combat Controls");
+            controls.setAnchor(WidgeCraft::Anchor::BottomCenter);
+            controls.setPosition(0.0f, 24.0f);
+            controls.setSize(430.0f, 82.0f);
+            controls.setBackgroundColor({ 0.040f, 0.055f, 0.078f, 0.94f });
+            controls.setBorderVisible(true);
+            controls.setBorderColor({ 0.25f, 0.48f, 0.68f, 1.0f });
+
+            auto& resizeMap = controls.addWidget<WidgeCraft::Button>(
+                "Resize Map",
+                "Expand map");
+            resizeMap.setAnchor(WidgeCraft::Anchor::CenterLeft);
+            resizeMap.setPosition(16.0f, 0.0f);
+            resizeMap.setSize(188.0f, 48.0f);
+            resizeMap.setTextSize(17.0f);
+            auto* resizeMapButton = &resizeMap;
+            resizeMap.setOnClick([this, resizeMapButton]() {
+                m_mapExpanded = !m_mapExpanded;
+                m_minimapFrame->setSize(
+                    m_mapExpanded ? 410.0f : 270.0f,
+                    m_mapExpanded ? 330.0f : 220.0f);
+                resizeMapButton->setText(
+                    m_mapExpanded ? "Shrink map" : "Expand map");
+            });
+
+            auto& back = controls.addWidget<WidgeCraft::Button>(
+                "Back",
+                "Character select");
+            back.setAnchor(WidgeCraft::Anchor::CenterRight);
+            back.setPosition(16.0f, 0.0f);
+            back.setSize(188.0f, 48.0f);
+            back.setTextSize(17.0f);
+            back.setOnClick([&app]() {
+                app.getSceneManager().request(CharacterSceneName);
+                app.getUiManager().request(CharacterUiName);
+            });
+        }
+
+        void onUpdate(
+            WidgeCraft::WidgeCraft& app,
+            float deltaTime) override {
+            (void)app;
+            (void)deltaTime;
+            m_minimap->getViewport().getCamera2D().setPosition(
+                m_state.playerMapPosition);
+
+            const int distanceTenths = static_cast<int>(
+                std::round(m_state.cameraDistance * 10.0f));
+            std::string status = m_state.cameraDistance <= 0.2f
+                ? "First person"
+                : "Camera "
+                    + std::to_string(distanceTenths / 10)
+                    + "."
+                    + std::to_string(distanceTenths % 10);
+            status += m_state.playerGrounded
+                ? "  |  Grounded"
+                : "  |  Falling";
+            if (m_state.selectedEnemyId != 0) {
+                status += "  |  Selected "
+                    + std::to_string(m_state.selectedEnemyId);
+            }
+            m_worldStatus->setText(std::move(status));
+        }
+
+    private:
+        void renderMinimap(
+            WidgeCraft::WidgeCraft& app,
+            const WidgeCraft::SceneView& view) const {
+
+            auto& shapes = app.getShapes2D();
+            for (int coordinate = -50; coordinate <= 50; coordinate += 5) {
+                const bool major = coordinate % 10 == 0;
+                const WidgeCraft::Color color = major
+                    ? WidgeCraft::Color{ 0.16f, 0.36f, 0.40f, 0.88f }
+                    : WidgeCraft::Color{ 0.09f, 0.22f, 0.25f, 0.72f };
+                shapes.drawLine(
+                    static_cast<float>(coordinate), -50.0f,
+                    static_cast<float>(coordinate), 50.0f,
+                    major ? 0.20f : 0.10f,
+                    color);
+                shapes.drawLine(
+                    -50.0f, static_cast<float>(coordinate),
+                    50.0f, static_cast<float>(coordinate),
+                    major ? 0.20f : 0.10f,
+                    color);
+            }
+
+            WidgeCraft::ShapeStyle2D player;
+            player.fillColor = { 0.35f, 0.88f, 1.0f, 1.0f };
+            player.edgeColor = WidgeCraft::Colors::White;
+            player.edgeThickness = 0.35f;
+            player.edgeVisible = true;
+            shapes.drawCircle(m_state.playerMapPosition, 1.2f, player);
+            const WidgeCraft::Vec2 heading{
+                std::sin(m_state.playerYaw),
+                -std::cos(m_state.playerYaw)
+            };
+            shapes.drawLine(
+                m_state.playerMapPosition.x,
+                m_state.playerMapPosition.y,
+                m_state.playerMapPosition.x + heading.x * 2.4f,
+                m_state.playerMapPosition.y + heading.y * 2.4f,
+                0.38f,
+                { 0.70f, 0.95f, 1.0f, 1.0f });
+
+            for (const EnemySpawn& spawn : EnemySpawns) {
+                const bool selected =
+                    spawn.id == m_state.selectedEnemyId;
+                WidgeCraft::ShapeStyle2D enemy;
+                enemy.fillColor = selected
+                    ? WidgeCraft::Color{ 1.0f, 0.82f, 0.18f, 1.0f }
+                    : WidgeCraft::Color{ 1.0f, 0.28f, 0.18f, 1.0f };
+                enemy.edgeColor = WidgeCraft::Colors::White;
+                enemy.edgeThickness = 0.28f;
+                enemy.edgeVisible = selected;
+                shapes.drawCircle(
+                    { spawn.position.x, spawn.position.z },
+                    std::max(spawn.halfExtents.x, spawn.halfExtents.z),
+                    enemy);
+            }
+
+            view.getViewport().drawLabel2D(
+                app.getTextRenderer(),
+                "You",
+                m_state.playerMapPosition,
+                13.0f,
+                { 0.78f, 0.94f, 1.0f, 1.0f },
+                { 10.0f, 8.0f });
+        }
+
+        DemoState& m_state;
+        WidgeCraft::Frame* m_minimapFrame = nullptr;
+        WidgeCraft::SceneView* m_minimap = nullptr;
+        WidgeCraft::Label* m_worldStatus = nullptr;
+        bool m_mapExpanded = false;
+    };
+
+} // namespace
+
+int main(int argumentCount, char** arguments) {
     try {
         WidgeCraft::WidgeCraft app(
-            "WidgeCraft Model Viewport Sandbox",
+            "WidgeCraft Interactive World Sandbox",
             1100,
             720);
         app.setClearColor({ 0.020f, 0.028f, 0.044f, 1.0f });
 
-        WidgeCraft::ModelViewport modelViewport;
-        modelViewport.getCamera2D().setPosition({ 0.0f, 0.0f });
-        modelViewport.getCamera2D().setZoom(1.0f);
-        modelViewport.getCamera3D().setPosition({ 6.0f, 4.5f, 9.0f });
-        modelViewport.getCamera3D().setTarget({ 0.0f, 0.0f, 0.0f });
-        modelViewport.getCamera3D().setPerspective(52.0f, 0.1f, 500.0f);
+        DemoState state;
+        app.getSceneManager().emplace<CharacterSelectScene>(
+            CharacterSceneName,
+            state);
+        app.getSceneManager().emplace<WorldScene>(
+            WorldSceneName,
+            state);
+        app.getUiManager().emplace<CharacterSelectUi>(
+            CharacterUiName,
+            app,
+            state);
+        app.getUiManager().emplace<CombatUi>(
+            CombatUiName,
+            app,
+            state);
 
-        auto& root = app.getRootFrame();
-        root.setBackgroundVisible(false);
-
-        auto& modelFrame = root.createChildFrame("Model Area");
-        modelFrame.setAnchor(WidgeCraft::Anchor::BottomLeft);
-        modelFrame.setPosition(28.0f, 28.0f);
-        modelFrame.setSize(1044.0f, 664.0f);
-        modelFrame.setBackgroundVisible(false);
-        modelFrame.setBorderVisible(true);
-        modelFrame.setBorderColor({ 0.22f, 0.43f, 0.68f, 1.0f });
-        modelFrame.setBorderThickness(3.0f);
-
-        auto& panel = root.createChildFrame("Controls");
-        panel.setAnchor(WidgeCraft::Anchor::TopLeft);
-        panel.setPosition(48.0f, 48.0f);
-        panel.setSize(360.0f, 214.0f);
-        panel.setBackgroundColor({ 0.055f, 0.072f, 0.105f, 0.96f });
-        panel.setBorderVisible(true);
-        panel.setBorderColor({ 0.25f, 0.46f, 0.70f, 1.0f });
-        panel.setBorderThickness(2.0f);
-
-        auto& title = panel.addWidget<WidgeCraft::Label>(
-            "Title",
-            "Model Viewport");
-        title.setAnchor(WidgeCraft::Anchor::TopLeft);
-        title.setPosition(20.0f, 16.0f);
-        title.setTextSize(28.0f);
-        title.setColor({ 0.76f, 0.91f, 1.0f, 1.0f });
-
-        auto& subtitle = panel.addWidget<WidgeCraft::Label>(
-            "Subtitle",
-            "Clipped 2D, 3D and scene text");
-        subtitle.setAnchor(WidgeCraft::Anchor::TopLeft);
-        subtitle.setPosition(20.0f, 54.0f);
-        subtitle.setTextSize(15.0f);
-        subtitle.setColor({ 0.63f, 0.72f, 0.84f, 1.0f });
-
-        auto& status = panel.addWidget<WidgeCraft::Label>(
-            "Status",
-            "Resize the window or change 2D zoom.");
-        status.setAnchor(WidgeCraft::Anchor::TopLeft);
-        status.setPosition(20.0f, 86.0f);
-        status.setSize(320.0f, 28.0f);
-        status.setTextSize(15.0f);
-        status.setColor({ 0.67f, 0.88f, 0.72f, 1.0f });
-
-        float cameraZoom = 1.0f;
-        bool show3D = true;
-
-        auto& zoomIn = panel.addWidget<WidgeCraft::Button>(
-            "Zoom In",
-            "Zoom +");
-        zoomIn.setAnchor(WidgeCraft::Anchor::BottomLeft);
-        zoomIn.setPosition(20.0f, 22.0f);
-        zoomIn.setSize(92.0f, 42.0f);
-        zoomIn.setTextSize(16.0f);
-        zoomIn.setOnClick([&]() {
-            cameraZoom = std::min(cameraZoom * 1.25f, 4.0f);
-            status.setText("2D zoom: " + std::to_string(cameraZoom));
-        });
-
-        auto& zoomOut = panel.addWidget<WidgeCraft::Button>(
-            "Zoom Out",
-            "Zoom -");
-        zoomOut.setAnchor(WidgeCraft::Anchor::BottomLeft);
-        zoomOut.setPosition(124.0f, 22.0f);
-        zoomOut.setSize(92.0f, 42.0f);
-        zoomOut.setTextSize(16.0f);
-        zoomOut.setOnClick([&]() {
-            cameraZoom = std::max(cameraZoom / 1.25f, 0.25f);
-            status.setText("2D zoom: " + std::to_string(cameraZoom));
-        });
-
-        auto& threeDToggle = panel.addWidget<WidgeCraft::Checkbox>(
-            "3D Toggle",
-            "Show 3D cubes",
-            show3D);
-        threeDToggle.setAnchor(WidgeCraft::Anchor::BottomRight);
-        threeDToggle.setPosition(20.0f, 31.0f);
-        threeDToggle.setTextSize(15.0f);
-        threeDToggle.setOnChanged([&](bool checked) {
-            show3D = checked;
-            status.setText(
-                checked ? "3D scene enabled." : "3D scene hidden.");
-        });
-
-        app.setRenderCallback([&](WidgeCraft::WidgeCraft& engine) {
-            const float windowWidth =
-                static_cast<float>(engine.getWindow().getWidth());
-            const float windowHeight =
-                static_cast<float>(engine.getWindow().getHeight());
-
-            modelFrame.setSize(
-                std::max(windowWidth - 56.0f, 40.0f),
-                std::max(windowHeight - 56.0f, 40.0f));
-
-            const WidgeCraft::Rect frameRect = modelFrame.getAbsoluteRect();
-            modelViewport.setScreenRect({
-                frameRect.x + 4.0f,
-                frameRect.y + 4.0f,
-                std::max(frameRect.width - 8.0f, 1.0f),
-                std::max(frameRect.height - 8.0f, 1.0f)
-            });
-            modelViewport.getCamera2D().setZoom(cameraZoom);
-            engine.useModelViewport(modelViewport);
-
-            auto& shapes2D = engine.getShapes2D();
-            auto& shapes3D = engine.getShapes3D();
-            auto& text = engine.getTextRenderer();
-
-            for (int x = -1200; x <= 1200; x += 80) {
-                const bool major = (x % 400) == 0;
-                shapes2D.drawLine(
-                    static_cast<float>(x), -900.0f,
-                    static_cast<float>(x), 900.0f,
-                    major ? 2.0f : 1.0f,
-                    major
-                        ? WidgeCraft::Color{ 0.14f, 0.26f, 0.38f, 0.72f }
-                        : WidgeCraft::Color{ 0.08f, 0.13f, 0.20f, 0.60f });
-            }
-            for (int y = -900; y <= 900; y += 80) {
-                const bool major = (y % 400) == 0;
-                shapes2D.drawLine(
-                    -1200.0f, static_cast<float>(y),
-                    1200.0f, static_cast<float>(y),
-                    major ? 2.0f : 1.0f,
-                    major
-                        ? WidgeCraft::Color{ 0.14f, 0.26f, 0.38f, 0.72f }
-                        : WidgeCraft::Color{ 0.08f, 0.13f, 0.20f, 0.60f });
-            }
-
-            WidgeCraft::ShapeStyle2D circleStyle;
-            circleStyle.fillColor = { 0.06f, 0.30f, 0.42f, 0.72f };
-            circleStyle.edgeColor = { 0.32f, 0.82f, 1.0f, 1.0f };
-            circleStyle.edgeThickness = 4.0f;
-            circleStyle.edgeVisible = true;
-            shapes2D.drawCircle({ -330.0f, -180.0f }, 92.0f, circleStyle);
-
-            WidgeCraft::ShapeStyle2D rectangleStyle;
-            rectangleStyle.fillColor = { 0.24f, 0.09f, 0.34f, 0.72f };
-            rectangleStyle.edgeColor = { 0.76f, 0.42f, 0.94f, 1.0f };
-            rectangleStyle.edgeThickness = 4.0f;
-            rectangleStyle.edgeVisible = true;
-            shapes2D.drawRect(
-                { 230.0f, -245.0f, 190.0f, 130.0f },
-                rectangleStyle);
-
-            WidgeCraft::ShapeStyle2D triangleStyle;
-            triangleStyle.fillColor = { 0.08f, 0.34f, 0.20f, 0.74f };
-            triangleStyle.edgeColor = { 0.38f, 0.92f, 0.58f, 1.0f };
-            triangleStyle.edgeThickness = 4.0f;
-            triangleStyle.edgeVisible = true;
-            shapes2D.drawTriangle(
-                { 315.0f, 260.0f },
-                { 425.0f, 70.0f },
-                { 205.0f, 70.0f },
-                triangleStyle);
-
-            modelViewport.drawWorldText2D(
-                text,
-                "2D world text",
-                { -430.0f, 275.0f },
-                28.0f,
-                { 0.76f, 0.90f, 1.0f, 1.0f });
-
-            if (show3D) {
-                WidgeCraft::ShapeStyle3D cubeStyle;
-                cubeStyle.fillColor = { 0.14f, 0.42f, 0.72f, 0.78f };
-                cubeStyle.edgeColor = { 0.72f, 0.90f, 1.0f, 1.0f };
-                cubeStyle.edgeThickness = 2.0f;
-                cubeStyle.edgeVisible = true;
-
-                shapes3D.drawCube({ -1.7f, 0.0f, 0.0f }, 1.8f, cubeStyle);
-                cubeStyle.fillColor = { 0.64f, 0.25f, 0.18f, 0.78f };
-                shapes3D.drawCube({ 1.2f, 0.5f, -1.0f }, 2.0f, cubeStyle);
-
-                modelViewport.drawLabel3D(
-                    text,
-                    "Cube A",
-                    { -1.7f, 1.15f, 0.0f },
-                    17.0f,
-                    { 0.84f, 0.94f, 1.0f, 1.0f });
-                modelViewport.drawWorldText3D(
-                    text,
-                    "World-sized",
-                    { 1.2f, 1.75f, -1.0f },
-                    0.45f,
-                    { 1.0f, 0.82f, 0.62f, 1.0f });
-            }
-        });
+        const bool startInWorld = argumentCount > 1
+            && std::string(arguments[1]) == "--world";
+        const char* initialScene = startInWorld
+            ? WorldSceneName
+            : CharacterSceneName;
+        const char* initialUi = startInWorld
+            ? CombatUiName
+            : CharacterUiName;
+        if (!app.getSceneManager().activate(initialScene)
+            || !app.getUiManager().activate(initialUi)) {
+            throw std::runtime_error(
+                "Failed to activate the initial scene and UI");
+        }
 
         app.Run(60);
     } catch (const std::exception& exception) {
-        std::cerr << "WidgeCraft viewport sandbox failed: "
+        std::cerr << "WidgeCraft management sandbox failed: "
                   << exception.what() << '\n';
         return 1;
     }

--- a/src/core/WidgeCraft.cpp
+++ b/src/core/WidgeCraft.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cmath>
 #include <filesystem>
+#include <stdexcept>
 #include <thread>
 #include <utility>
 
@@ -56,14 +57,15 @@ namespace WidgeCraft {
             resolveFontPath(fontPath),
             fontPixelHeight)
         , m_shapes2D()
-        , m_shapes3D() {
+        , m_shapes3D()
+        , m_sceneManager(*this)
+        , m_uiManager(*this) {
         initializeGraphics();
     }
 
     WidgeCraft::~WidgeCraft() {
-        if (m_scene) {
-            m_scene->onDetach(*this);
-        }
+        m_uiManager.shutdown();
+        m_sceneManager.shutdown();
     }
 
     void WidgeCraft::Run(int targetFramesPerSecond) {
@@ -102,22 +104,21 @@ namespace WidgeCraft {
     }
 
     void WidgeCraft::setScene(std::unique_ptr<Scene> scene) {
-        if (m_scene) {
-            m_scene->onDetach(*this);
-        }
-        m_scene = std::move(scene);
-        if (m_scene) {
-            m_scene->onAttach(*this);
-        }
+        m_sceneManager.setTransient(std::move(scene));
     }
 
     void WidgeCraft::useModelViewport(
         const ModelViewport& viewport) {
 
+        // A renderer stores only one current 3D matrix. Flush anything already
+        // queued before selecting the next camera/clip combination.
+        flushSceneQueues();
+
         m_modelViewportRect = viewport.getScreenRect();
         m_modelViewportActive =
             m_modelViewportRect.width > 0.0f
             && m_modelViewportRect.height > 0.0f;
+        m_modelViewportOptions = {};
 
         if (!m_modelViewportActive) {
             m_shapes2D.resetTransform();
@@ -128,9 +129,53 @@ namespace WidgeCraft {
     }
 
     void WidgeCraft::clearModelViewport() {
-        m_modelViewportActive = false;
-        m_modelViewportRect = {};
-        m_shapes2D.resetTransform();
+        if (m_modelViewportActive) {
+            flushSceneQueues();
+        } else {
+            m_shapes2D.resetTransform();
+        }
+    }
+
+    void WidgeCraft::renderViewport(
+        const ModelViewport& viewport,
+        const ViewportRenderCallback& callback,
+        const ViewportRenderOptions& options) {
+
+        if (!callback) {
+            return;
+        }
+        if (m_viewportCallbackActive) {
+            throw std::logic_error(
+                "Viewport render callbacks cannot be nested");
+        }
+
+        flushSceneQueues();
+        m_modelViewportRect = viewport.getScreenRect();
+        m_modelViewportActive =
+            m_modelViewportRect.width > 0.0f
+            && m_modelViewportRect.height > 0.0f;
+        m_modelViewportOptions = options;
+
+        if (!m_modelViewportActive) {
+            return;
+        }
+
+        viewport.configureRenderers(m_shapes2D, m_shapes3D);
+        m_viewportCallbackActive = true;
+        try {
+            callback(*this);
+            m_viewportCallbackActive = false;
+            flushSceneQueues();
+        } catch (...) {
+            m_viewportCallbackActive = false;
+            m_shapes3D.beginFrame();
+            m_shapes2D.beginFrame();
+            m_textRenderer.beginFrame();
+            m_modelViewportActive = false;
+            m_modelViewportRect = {};
+            restoreFullFramebufferState();
+            throw;
+        }
     }
 
     void WidgeCraft::Update() {
@@ -141,9 +186,12 @@ namespace WidgeCraft {
             static_cast<float>(m_window.getWidth()),
             static_cast<float>(m_window.getHeight()));
 
-        if (m_scene) {
-            m_scene->onUpdate(*this, m_deltaTime);
-        }
+        // Scene and UI requests are applied together at the same safe frame
+        // boundary before either newly active object receives an update.
+        m_sceneManager.applyPending();
+        m_uiManager.applyPending();
+        m_sceneManager.update(m_deltaTime);
+        m_uiManager.update(m_deltaTime);
         if (m_updateCallback) {
             m_updateCallback(*this);
         }
@@ -167,59 +215,94 @@ namespace WidgeCraft {
         m_textRenderer.beginFrame();
         m_modelViewportActive = false;
         m_modelViewportRect = {};
+        m_modelViewportOptions = {};
 
-        if (m_scene) {
-            m_scene->onRender(*this);
-        }
+        m_sceneManager.render();
         if (m_renderCallback) {
             m_renderCallback(*this);
         }
+        m_uiManager.renderSceneViews();
 
-        if (m_modelViewportActive) {
-            const Rect clipped = clipToFramebuffer(
-                m_modelViewportRect,
-                framebufferWidth,
-                framebufferHeight);
-
-            const int left = static_cast<int>(std::floor(clipped.x));
-            const int bottom = static_cast<int>(std::floor(clipped.y));
-            const int right = static_cast<int>(std::ceil(clipped.right()));
-            const int top = static_cast<int>(std::ceil(clipped.top()));
-            const int clipWidth = std::max(0, right - left);
-            const int clipHeight = std::max(0, top - bottom);
-
-            glEnable(GL_SCISSOR_TEST);
-            glScissor(left, bottom, clipWidth, clipHeight);
-
-            // 3D uses the model rectangle as its OpenGL viewport. The camera
-            // projection was built from the same aspect ratio.
-            glViewport(left, bottom, clipWidth, clipHeight);
-            m_shapes3D.flush();
-
-            // 2D shapes and text are already transformed into full-framebuffer
-            // coordinates, so only scissoring remains active for these passes.
-            glViewport(0, 0, framebufferWidth, framebufferHeight);
-            m_shapes2D.flush();
-            m_textRenderer.flush();
-
-            glDisable(GL_SCISSOR_TEST);
-        } else {
-            m_shapes3D.flush();
-            m_shapes2D.flush();
-            m_textRenderer.flush();
-        }
+        flushSceneQueues();
 
         // Retained UI always renders in native framebuffer pixels. Scene
         // transforms, clipping and the 3D viewport cannot stretch or crop it.
-        glViewport(0, 0, framebufferWidth, framebufferHeight);
-        glDisable(GL_SCISSOR_TEST);
-        m_shapes2D.resetTransform();
+        restoreFullFramebufferState();
         m_window.getRootFrame().render(
             m_textRenderer,
             m_shapes2D,
             m_window.getInput());
+        m_uiManager.renderUi();
         m_shapes2D.flush();
         m_textRenderer.flush();
+    }
+
+    void WidgeCraft::flushSceneQueues() {
+        const int framebufferWidth = m_window.getWidth();
+        const int framebufferHeight = m_window.getHeight();
+
+        if (!m_modelViewportActive) {
+            restoreFullFramebufferState();
+            m_shapes3D.flush();
+            m_shapes2D.flush();
+            m_textRenderer.flush();
+            return;
+        }
+
+        const Rect clipped = clipToFramebuffer(
+            m_modelViewportRect,
+            framebufferWidth,
+            framebufferHeight);
+
+        const int left = static_cast<int>(std::floor(clipped.x));
+        const int bottom = static_cast<int>(std::floor(clipped.y));
+        const int right = static_cast<int>(std::ceil(clipped.right()));
+        const int top = static_cast<int>(std::ceil(clipped.top()));
+        const int clipWidth = std::max(0, right - left);
+        const int clipHeight = std::max(0, top - bottom);
+
+        glEnable(GL_SCISSOR_TEST);
+        glScissor(left, bottom, clipWidth, clipHeight);
+        glViewport(left, bottom, clipWidth, clipHeight);
+
+        GLbitfield clearMask = 0;
+        if (m_modelViewportOptions.clearColor) {
+            const Color color = m_modelViewportOptions.color;
+            glClearColor(color.r, color.g, color.b, color.a);
+            clearMask |= GL_COLOR_BUFFER_BIT;
+        }
+        if (m_modelViewportOptions.clearDepth) {
+            clearMask |= GL_DEPTH_BUFFER_BIT;
+        }
+        if (clearMask != 0 && clipWidth > 0 && clipHeight > 0) {
+            glClear(clearMask);
+        }
+
+        // 3D uses the model rectangle as its OpenGL viewport. Its depth area is
+        // cleared per pass so an overlaid minimap cannot inherit world depth.
+        m_shapes3D.flush();
+
+        // 2D vertices and scene text use full-framebuffer pixel coordinates;
+        // the viewport's scissor remains active while the full viewport returns.
+        glViewport(0, 0, framebufferWidth, framebufferHeight);
+        m_shapes2D.flush();
+        m_textRenderer.flush();
+
+        m_modelViewportActive = false;
+        m_modelViewportRect = {};
+        m_modelViewportOptions = {};
+        restoreFullFramebufferState();
+    }
+
+    void WidgeCraft::restoreFullFramebufferState() {
+        glViewport(0, 0, m_window.getWidth(), m_window.getHeight());
+        glDisable(GL_SCISSOR_TEST);
+        glClearColor(
+            m_clearColor.r,
+            m_clearColor.g,
+            m_clearColor.b,
+            m_clearColor.a);
+        m_shapes2D.resetTransform();
     }
 
     void WidgeCraft::initializeGraphics() {

--- a/src/physics/PhysicsWorld.cpp
+++ b/src/physics/PhysicsWorld.cpp
@@ -1,0 +1,326 @@
+#include "WidgeCraft/physics/PhysicsWorld.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace WidgeCraft {
+
+    namespace {
+        bool calculateOverlap(
+            const PhysicsBody& first,
+            const PhysicsBody& second,
+            Vec3& normal,
+            float& penetration) {
+
+            const AABB firstBounds = first.getBounds();
+            const AABB secondBounds = second.getBounds();
+            const float overlapX = std::min(
+                firstBounds.maximum.x,
+                secondBounds.maximum.x)
+                - std::max(
+                    firstBounds.minimum.x,
+                    secondBounds.minimum.x);
+            const float overlapY = std::min(
+                firstBounds.maximum.y,
+                secondBounds.maximum.y)
+                - std::max(
+                    firstBounds.minimum.y,
+                    secondBounds.minimum.y);
+            const float overlapZ = std::min(
+                firstBounds.maximum.z,
+                secondBounds.maximum.z)
+                - std::max(
+                    firstBounds.minimum.z,
+                    secondBounds.minimum.z);
+
+            if (overlapX <= 0.0f || overlapY <= 0.0f || overlapZ <= 0.0f) {
+                return false;
+            }
+
+            const Vec3 firstCenter =
+                (firstBounds.minimum + firstBounds.maximum) * 0.5f;
+            const Vec3 secondCenter =
+                (secondBounds.minimum + secondBounds.maximum) * 0.5f;
+            const Vec3 centerDelta = firstCenter - secondCenter;
+
+            penetration = overlapX;
+            normal = { centerDelta.x < 0.0f ? -1.0f : 1.0f, 0.0f, 0.0f };
+            if (overlapY < penetration) {
+                penetration = overlapY;
+                normal = {
+                    0.0f,
+                    centerDelta.y < 0.0f ? -1.0f : 1.0f,
+                    0.0f
+                };
+            }
+            if (overlapZ < penetration) {
+                penetration = overlapZ;
+                normal = {
+                    0.0f,
+                    0.0f,
+                    centerDelta.z < 0.0f ? -1.0f : 1.0f
+                };
+            }
+            return true;
+        }
+    } // namespace
+
+    PhysicsBody::PhysicsBody(
+        PhysicsBodyId id,
+        PhysicsBodyType type,
+        const Vec3& position,
+        const BoxCollider& collider)
+        : m_id(id)
+        , m_type(type)
+        , m_position(position)
+        , m_collider(collider) {
+    }
+
+    void PhysicsBody::setType(PhysicsBodyType type) {
+        m_type = type;
+        m_grounded = false;
+        if (isStatic()) {
+            m_velocity = {};
+        }
+    }
+
+    void PhysicsBody::setMass(float mass) {
+        m_mass = std::max(mass, 0.001f);
+    }
+
+    void PhysicsBody::setGravityScale(float scale) {
+        m_gravityScale = std::max(scale, 0.0f);
+    }
+
+    AABB PhysicsBody::getBounds() const {
+        const Vec3 center = m_position + m_collider.offset;
+        const Vec3 halfExtents{
+            std::max(std::abs(m_collider.halfExtents.x), 0.001f),
+            std::max(std::abs(m_collider.halfExtents.y), 0.001f),
+            std::max(std::abs(m_collider.halfExtents.z), 0.001f)
+        };
+        return {
+            center - halfExtents,
+            center + halfExtents
+        };
+    }
+
+    float PhysicsBody::inverseMass() const {
+        return isDynamic() && m_enabled ? 1.0f / m_mass : 0.0f;
+    }
+
+    PhysicsBody& PhysicsWorld::createBody(
+        PhysicsBodyType type,
+        const Vec3& position,
+        const BoxCollider& collider,
+        PhysicsBodyId requestedId) {
+
+        const PhysicsBodyId id = requestedId == 0
+            ? allocateId()
+            : requestedId;
+        if (findBody(id)) {
+            throw std::invalid_argument(
+                "A physics body with the requested ID already exists");
+        }
+
+        m_nextId = std::max(m_nextId, id + 1);
+        auto body = std::unique_ptr<PhysicsBody>(
+            new PhysicsBody(id, type, position, collider));
+        PhysicsBody& reference = *body;
+        m_bodies.emplace_back(std::move(body));
+        return reference;
+    }
+
+    PhysicsBody* PhysicsWorld::findBody(PhysicsBodyId id) {
+        const auto iterator = std::find_if(
+            m_bodies.begin(),
+            m_bodies.end(),
+            [id](const auto& body) {
+                return body && body->getId() == id;
+            });
+        return iterator != m_bodies.end() ? iterator->get() : nullptr;
+    }
+
+    const PhysicsBody* PhysicsWorld::findBody(PhysicsBodyId id) const {
+        const auto iterator = std::find_if(
+            m_bodies.begin(),
+            m_bodies.end(),
+            [id](const auto& body) {
+                return body && body->getId() == id;
+            });
+        return iterator != m_bodies.end() ? iterator->get() : nullptr;
+    }
+
+    bool PhysicsWorld::removeBody(PhysicsBodyId id) {
+        const auto iterator = std::find_if(
+            m_bodies.begin(),
+            m_bodies.end(),
+            [id](const auto& body) {
+                return body && body->getId() == id;
+            });
+        if (iterator == m_bodies.end()) {
+            return false;
+        }
+        m_bodies.erase(iterator);
+        return true;
+    }
+
+    void PhysicsWorld::clear() {
+        m_bodies.clear();
+        m_collisions.clear();
+        m_nextId = 1;
+    }
+
+    void PhysicsWorld::setMaximumStep(float seconds) {
+        m_maximumStep = std::clamp(seconds, 1.0e-4f, 0.1f);
+    }
+
+    void PhysicsWorld::setSolverIterations(int iterations) {
+        m_solverIterations = std::clamp(iterations, 1, 32);
+    }
+
+    void PhysicsWorld::step(float deltaTime) {
+        const float frameTime = std::clamp(deltaTime, 0.0f, 0.25f);
+        if (frameTime <= 0.0f) {
+            return;
+        }
+
+        m_collisions.clear();
+        for (auto& body : m_bodies) {
+            if (body && body->isDynamic()) {
+                body->m_grounded = false;
+            }
+        }
+
+        const int substepCount = std::max(
+            1,
+            static_cast<int>(std::ceil(frameTime / m_maximumStep)));
+        const float substepTime = frameTime
+            / static_cast<float>(substepCount);
+        for (int substep = 0; substep < substepCount; ++substep) {
+            integrate(substepTime);
+            for (int iteration = 0;
+                 iteration < m_solverIterations;
+                 ++iteration) {
+                solveCollisions();
+            }
+        }
+    }
+
+    void PhysicsWorld::integrate(float deltaTime) {
+        for (auto& body : m_bodies) {
+            if (!body || !body->isEnabled() || !body->isDynamic()) {
+                continue;
+            }
+            body->m_velocity +=
+                m_gravity * (body->m_gravityScale * deltaTime);
+            body->m_position += body->m_velocity * deltaTime;
+        }
+    }
+
+    void PhysicsWorld::solveCollisions() {
+        for (std::size_t firstIndex = 0;
+             firstIndex < m_bodies.size();
+             ++firstIndex) {
+            PhysicsBody* first = m_bodies[firstIndex].get();
+            if (!first || !first->isEnabled()) {
+                continue;
+            }
+
+            for (std::size_t secondIndex = firstIndex + 1;
+                 secondIndex < m_bodies.size();
+                 ++secondIndex) {
+                PhysicsBody* second = m_bodies[secondIndex].get();
+                if (!second || !second->isEnabled()) {
+                    continue;
+                }
+
+                const float firstInverseMass = first->inverseMass();
+                const float secondInverseMass = second->inverseMass();
+                const float inverseMassSum =
+                    firstInverseMass + secondInverseMass;
+                if (inverseMassSum <= 0.0f) {
+                    continue;
+                }
+
+                Vec3 normal{};
+                float penetration = 0.0f;
+                if (!calculateOverlap(
+                        *first,
+                        *second,
+                        normal,
+                        penetration)) {
+                    continue;
+                }
+
+                const Vec3 correction = normal * penetration;
+                first->m_position += correction
+                    * (firstInverseMass / inverseMassSum);
+                second->m_position -= correction
+                    * (secondInverseMass / inverseMassSum);
+
+                const Vec3 relativeVelocity =
+                    first->m_velocity - second->m_velocity;
+                const float normalVelocity = dot(relativeVelocity, normal);
+                if (normalVelocity < 0.0f) {
+                    const float impulseMagnitude =
+                        -normalVelocity / inverseMassSum;
+                    first->m_velocity += normal
+                        * (impulseMagnitude * firstInverseMass);
+                    second->m_velocity -= normal
+                        * (impulseMagnitude * secondInverseMass);
+                }
+
+                if (first->isDynamic() && normal.y > 0.5f) {
+                    first->m_grounded = true;
+                }
+                if (second->isDynamic() && normal.y < -0.5f) {
+                    second->m_grounded = true;
+                }
+
+                recordCollision(
+                    *first,
+                    *second,
+                    normal,
+                    penetration);
+            }
+        }
+    }
+
+    void PhysicsWorld::recordCollision(
+        const PhysicsBody& first,
+        const PhysicsBody& second,
+        const Vec3& normal,
+        float penetration) {
+
+        const auto iterator = std::find_if(
+            m_collisions.begin(),
+            m_collisions.end(),
+            [&](const PhysicsCollision& collision) {
+                return collision.firstBody == first.getId()
+                    && collision.secondBody == second.getId();
+            });
+        if (iterator != m_collisions.end()) {
+            if (penetration > iterator->penetration) {
+                iterator->normal = normal;
+                iterator->penetration = penetration;
+            }
+            return;
+        }
+        m_collisions.push_back({
+            first.getId(),
+            second.getId(),
+            normal,
+            penetration
+        });
+    }
+
+    PhysicsBodyId PhysicsWorld::allocateId() {
+        while (findBody(m_nextId)) {
+            ++m_nextId;
+        }
+        return m_nextId++;
+    }
+
+} // namespace WidgeCraft

--- a/src/scene/SceneManager.cpp
+++ b/src/scene/SceneManager.cpp
@@ -1,0 +1,186 @@
+#include "WidgeCraft/scene/SceneManager.hpp"
+
+#include "WidgeCraft/WidgeCraft.hpp"
+
+#include <utility>
+
+namespace WidgeCraft {
+
+    SceneManager::SceneManager(WidgeCraft& app)
+        : m_app(app) {
+    }
+
+    Scene& SceneManager::add(
+        std::string name,
+        std::unique_ptr<Scene> scene) {
+
+        if (name.empty()) {
+            throw std::invalid_argument("Scene names cannot be empty");
+        }
+        if (!scene) {
+            throw std::invalid_argument("Cannot add a null scene");
+        }
+        if (contains(name)) {
+            throw std::invalid_argument(
+                "A scene named '" + name + "' is already registered");
+        }
+
+        Scene& reference = *scene;
+        m_scenes.emplace(std::move(name), std::move(scene));
+        return reference;
+    }
+
+    Scene* SceneManager::find(const std::string& name) {
+        const auto iterator = m_scenes.find(name);
+        return iterator != m_scenes.end() ? iterator->second.get() : nullptr;
+    }
+
+    const Scene* SceneManager::find(const std::string& name) const {
+        const auto iterator = m_scenes.find(name);
+        return iterator != m_scenes.end() ? iterator->second.get() : nullptr;
+    }
+
+    bool SceneManager::contains(const std::string& name) const {
+        return find(name) != nullptr;
+    }
+
+    bool SceneManager::remove(const std::string& name) {
+        Scene* scene = find(name);
+        if (!scene || scene == m_active) {
+            return false;
+        }
+        if (m_pendingName && *m_pendingName == name) {
+            m_pendingName.reset();
+        }
+        return m_scenes.erase(name) > 0U;
+    }
+
+    bool SceneManager::activate(const std::string& name) {
+        Scene* scene = find(name);
+        if (!scene) {
+            return false;
+        }
+        if (m_dispatching) {
+            return request(name);
+        }
+        activateNow(scene, name);
+        return true;
+    }
+
+    void SceneManager::clearActive() {
+        if (m_dispatching) {
+            requestClear();
+            return;
+        }
+        activateNow(nullptr, {});
+    }
+
+    bool SceneManager::request(const std::string& name) {
+        if (!contains(name)) {
+            return false;
+        }
+        m_pendingName = name;
+        return true;
+    }
+
+    void SceneManager::requestClear() {
+        m_pendingName = std::string{};
+    }
+
+    void SceneManager::setTransient(std::unique_ptr<Scene> scene) {
+        if (m_dispatching) {
+            throw std::logic_error(
+                "setScene cannot replace a scene during its callback; "
+                "register it and request the named scene instead");
+        }
+
+        if (m_active) {
+            m_active->onDetach(m_app);
+        }
+        m_active = nullptr;
+        m_activeName.clear();
+        m_transient = std::move(scene);
+        m_active = m_transient.get();
+        if (m_active) {
+            m_active->onAttach(m_app);
+        }
+    }
+
+    void SceneManager::applyPending() {
+        if (!m_pendingName) {
+            return;
+        }
+
+        std::string name = std::move(*m_pendingName);
+        m_pendingName.reset();
+        if (name.empty()) {
+            activateNow(nullptr, {});
+            return;
+        }
+
+        if (Scene* scene = find(name)) {
+            activateNow(scene, std::move(name));
+        }
+    }
+
+    void SceneManager::update(float deltaTime) {
+        if (!m_active) {
+            return;
+        }
+        m_dispatching = true;
+        try {
+            m_active->onUpdate(m_app, deltaTime);
+        } catch (...) {
+            m_dispatching = false;
+            throw;
+        }
+        m_dispatching = false;
+    }
+
+    void SceneManager::render() {
+        if (!m_active) {
+            return;
+        }
+        m_dispatching = true;
+        try {
+            m_active->onRender(m_app);
+        } catch (...) {
+            m_dispatching = false;
+            throw;
+        }
+        m_dispatching = false;
+    }
+
+    void SceneManager::shutdown() {
+        m_pendingName.reset();
+        if (m_active) {
+            m_active->onDetach(m_app);
+        }
+        m_active = nullptr;
+        m_activeName.clear();
+        m_transient.reset();
+        m_scenes.clear();
+    }
+
+    void SceneManager::activateNow(Scene* scene, std::string name) {
+        if (scene == m_active) {
+            m_activeName = std::move(name);
+            return;
+        }
+
+        if (m_active) {
+            m_active->onDetach(m_app);
+        }
+
+        m_active = scene;
+        m_activeName = std::move(name);
+        if (m_active != m_transient.get()) {
+            m_transient.reset();
+        }
+
+        if (m_active) {
+            m_active->onAttach(m_app);
+        }
+    }
+
+} // namespace WidgeCraft

--- a/src/ui/Frame.cpp
+++ b/src/ui/Frame.cpp
@@ -101,6 +101,18 @@ namespace WidgeCraft {
         return { position.x, position.y, m_size.x, m_size.y };
     }
 
+    Rect Frame::getVisibleRect() const {
+        Rect visible = getAbsoluteRect();
+        for (const Frame* ancestor = m_parent;
+             ancestor;
+             ancestor = ancestor->m_parent) {
+            if (ancestor->clipsContents()) {
+                visible = intersect(visible, ancestor->getAbsoluteRect());
+            }
+        }
+        return visible;
+    }
+
     Frame& Frame::createChildFrame(const std::string& name) {
         if (findChildFrame(name)) {
             throw std::invalid_argument("A child frame named '" + name + "' already exists in frame '" + m_name + "'");

--- a/src/ui/UiManager.cpp
+++ b/src/ui/UiManager.cpp
@@ -1,0 +1,189 @@
+#include "WidgeCraft/ui/UiManager.hpp"
+
+#include "WidgeCraft/WidgeCraft.hpp"
+
+#include <utility>
+
+namespace WidgeCraft {
+
+    UiManager::UiManager(WidgeCraft& app)
+        : m_app(app) {
+    }
+
+    UiScreen& UiManager::add(
+        std::string name,
+        std::unique_ptr<UiScreen> screen) {
+
+        if (name.empty()) {
+            throw std::invalid_argument("UI registration names cannot be empty");
+        }
+        if (!screen) {
+            throw std::invalid_argument("Cannot add a null UI screen");
+        }
+        if (contains(name)) {
+            throw std::invalid_argument(
+                "A UI screen named '" + name + "' is already registered");
+        }
+
+        UiScreen& reference = *screen;
+        m_screens.emplace(std::move(name), std::move(screen));
+        return reference;
+    }
+
+    UiScreen* UiManager::find(const std::string& name) {
+        const auto iterator = m_screens.find(name);
+        return iterator != m_screens.end() ? iterator->second.get() : nullptr;
+    }
+
+    const UiScreen* UiManager::find(const std::string& name) const {
+        const auto iterator = m_screens.find(name);
+        return iterator != m_screens.end() ? iterator->second.get() : nullptr;
+    }
+
+    bool UiManager::contains(const std::string& name) const {
+        return find(name) != nullptr;
+    }
+
+    bool UiManager::remove(const std::string& name) {
+        UiScreen* screen = find(name);
+        if (!screen || screen == m_active) {
+            return false;
+        }
+        if (m_pendingName && *m_pendingName == name) {
+            m_pendingName.reset();
+        }
+        return m_screens.erase(name) > 0U;
+    }
+
+    bool UiManager::activate(const std::string& name) {
+        UiScreen* screen = find(name);
+        if (!screen) {
+            return false;
+        }
+        if (m_dispatching) {
+            return request(name);
+        }
+        activateNow(screen, name);
+        return true;
+    }
+
+    void UiManager::clearActive() {
+        if (m_dispatching) {
+            requestClear();
+            return;
+        }
+        activateNow(nullptr, {});
+    }
+
+    bool UiManager::request(const std::string& name) {
+        if (!contains(name)) {
+            return false;
+        }
+        m_pendingName = name;
+        return true;
+    }
+
+    void UiManager::requestClear() {
+        m_pendingName = std::string{};
+    }
+
+    void UiManager::applyPending() {
+        if (!m_pendingName) {
+            return;
+        }
+
+        std::string name = std::move(*m_pendingName);
+        m_pendingName.reset();
+        if (name.empty()) {
+            activateNow(nullptr, {});
+            return;
+        }
+
+        if (UiScreen* screen = find(name)) {
+            activateNow(screen, std::move(name));
+        }
+    }
+
+    void UiManager::update(float deltaTime) {
+        if (!m_active) {
+            return;
+        }
+        synchronizeRoot(*m_active);
+        m_dispatching = true;
+        try {
+            m_active->onUpdate(m_app, deltaTime);
+        } catch (...) {
+            m_dispatching = false;
+            throw;
+        }
+        m_dispatching = false;
+    }
+
+    void UiManager::renderSceneViews() {
+        if (!m_active) {
+            return;
+        }
+        synchronizeRoot(*m_active);
+        m_dispatching = true;
+        try {
+            m_active->onRender(m_app);
+            m_active->renderSceneViews(m_app);
+        } catch (...) {
+            m_dispatching = false;
+            throw;
+        }
+        m_dispatching = false;
+    }
+
+    void UiManager::renderUi() {
+        if (!m_active) {
+            return;
+        }
+        synchronizeRoot(*m_active);
+        m_dispatching = true;
+        try {
+            m_active->getRootFrame().render(
+                m_app.getTextRenderer(),
+                m_app.getShapes2D(),
+                m_app.getInput());
+        } catch (...) {
+            m_dispatching = false;
+            throw;
+        }
+        m_dispatching = false;
+    }
+
+    void UiManager::shutdown() {
+        m_pendingName.reset();
+        if (m_active) {
+            m_active->onDetach(m_app);
+        }
+        m_active = nullptr;
+        m_activeName.clear();
+        m_screens.clear();
+    }
+
+    void UiManager::activateNow(UiScreen* screen, std::string name) {
+        if (screen == m_active) {
+            m_activeName = std::move(name);
+            return;
+        }
+
+        if (m_active) {
+            m_active->onDetach(m_app);
+        }
+        m_active = screen;
+        m_activeName = std::move(name);
+        if (m_active) {
+            synchronizeRoot(*m_active);
+            m_active->onAttach(m_app);
+        }
+    }
+
+    void UiManager::synchronizeRoot(UiScreen& screen) {
+        screen.setScreenSize(
+            static_cast<float>(m_app.getWindow().getWidth()),
+            static_cast<float>(m_app.getWindow().getHeight()));
+    }
+
+} // namespace WidgeCraft

--- a/src/ui/UiScreen.cpp
+++ b/src/ui/UiScreen.cpp
@@ -1,0 +1,154 @@
+#include "WidgeCraft/ui/UiScreen.hpp"
+
+#include "WidgeCraft/WidgeCraft.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+namespace WidgeCraft {
+
+    SceneView::SceneView(std::string name, Frame& frame)
+        : m_name(std::move(name))
+        , m_frame(&frame) {
+        if (m_name.empty()) {
+            throw std::invalid_argument("Scene view names cannot be empty");
+        }
+    }
+
+    void SceneView::setInset(float inset) {
+        const float sanitized = std::max(0.0f, inset);
+        setInsets(sanitized, sanitized, sanitized, sanitized);
+    }
+
+    void SceneView::setInsets(
+        float left,
+        float bottom,
+        float right,
+        float top) {
+
+        m_leftInset = std::max(0.0f, left);
+        m_bottomInset = std::max(0.0f, bottom);
+        m_rightInset = std::max(0.0f, right);
+        m_topInset = std::max(0.0f, top);
+    }
+
+    void SceneView::render(WidgeCraft& app) {
+        if (!m_visible || !m_renderCallback || !m_frame
+            || !m_frame->isVisibleInHierarchy()) {
+            return;
+        }
+
+        const Rect frameRect = m_frame->getAbsoluteRect();
+        const Rect insetRect{
+            frameRect.x + m_leftInset,
+            frameRect.y + m_bottomInset,
+            std::max(
+                frameRect.width - m_leftInset - m_rightInset,
+                0.0f),
+            std::max(
+                frameRect.height - m_bottomInset - m_topInset,
+                0.0f)
+        };
+        const Rect viewportRect = intersect(
+            insetRect,
+            m_frame->getVisibleRect());
+        if (viewportRect.width <= 0.0f || viewportRect.height <= 0.0f) {
+            return;
+        }
+
+        m_viewport.setScreenRect(viewportRect);
+        ViewportRenderOptions options;
+        options.clearColor = m_clearsColor;
+        options.color = m_clearColor;
+        options.clearDepth = true;
+
+        app.renderViewport(
+            m_viewport,
+            [this](WidgeCraft& engine) {
+                m_renderCallback(engine, *this);
+            },
+            options);
+    }
+
+    UiScreen::UiScreen(std::string name)
+        : m_name(std::move(name))
+        , m_rootFrame(m_name + " Root") {
+        if (m_name.empty()) {
+            throw std::invalid_argument("UI screen names cannot be empty");
+        }
+        m_rootFrame.setDeletable(false);
+        m_rootFrame.setAnchor(Anchor::BottomLeft);
+        m_rootFrame.setPosition(0.0f, 0.0f);
+        m_rootFrame.setBackgroundVisible(false);
+        m_rootFrame.setBorderVisible(false);
+        m_rootFrame.setClipContents(true);
+    }
+
+    SceneView& UiScreen::createSceneView(
+        const std::string& name,
+        Frame& frame) {
+
+        if (findSceneView(name)) {
+            throw std::invalid_argument(
+                "A scene view named '" + name
+                + "' already exists in UI screen '" + m_name + "'");
+        }
+
+        auto view = std::make_unique<SceneView>(name, frame);
+        SceneView& reference = *view;
+        m_sceneViews.emplace_back(std::move(view));
+        return reference;
+    }
+
+    SceneView* UiScreen::findSceneView(const std::string& name) {
+        const auto iterator = std::find_if(
+            m_sceneViews.begin(),
+            m_sceneViews.end(),
+            [&](const auto& view) {
+                return view && view->getName() == name;
+            });
+        return iterator != m_sceneViews.end() ? iterator->get() : nullptr;
+    }
+
+    const SceneView* UiScreen::findSceneView(
+        const std::string& name) const {
+
+        const auto iterator = std::find_if(
+            m_sceneViews.begin(),
+            m_sceneViews.end(),
+            [&](const auto& view) {
+                return view && view->getName() == name;
+            });
+        return iterator != m_sceneViews.end() ? iterator->get() : nullptr;
+    }
+
+    bool UiScreen::removeSceneView(const std::string& name) {
+        const auto iterator = std::find_if(
+            m_sceneViews.begin(),
+            m_sceneViews.end(),
+            [&](const auto& view) {
+                return view && view->getName() == name;
+            });
+        if (iterator == m_sceneViews.end()) {
+            return false;
+        }
+        m_sceneViews.erase(iterator);
+        return true;
+    }
+
+    void UiScreen::setScreenSize(float width, float height) {
+        m_rootFrame.setSize(
+            std::max(width, 0.0f),
+            std::max(height, 0.0f));
+    }
+
+    void UiScreen::renderSceneViews(WidgeCraft& app) {
+        for (auto& view : m_sceneViews) {
+            if (view) {
+                view->render(app);
+            }
+        }
+    }
+
+} // namespace WidgeCraft


### PR DESCRIPTION
## What changed

- Added deferred scene and UI screen managers for safely swapping active game states.
- Added independently clipped scene views that bind model viewports to UI frames, including minimap-style embedded views.
- Extended rendering so each viewport uses its own camera, aspect ratio, depth state, clipping, and optional clear pass.
- Added AABB colliders and a physics world with static/dynamic bodies, gravity, grounded state, substeps, and collision resolution.
- Expanded the sandbox with a character-select flow and an interactive 3D world: WASD movement, right-drag camera control, scroll zoom into first person, enemy raycast selection, selected-object labels, collisions, and a tracking minimap.
- Updated the public headers, build configuration, engine version, and documentation.

## Why

WidgeCraft needs reusable scene and UI lifecycle management for applications that switch between menus, loading screens, world scenes, combat overlays, and embedded scene frames. The controller and physics additions provide a working integration example for camera following, picking, collision, and gravity.

## Impact

Engine users can dynamically activate scenes and UI screens, render additional camera views inside UI frames, and use the new physics section for basic collision-driven movement. Existing callback-based rendering remains available.

## Validation

- Configured and built the Visual Studio 2022 Win32 Release solution successfully.
- Built the engine and `widgecraft_ui_sandbox` target.
- Passed a standalone gravity and collider physics smoke test.
- Ran the sandbox directly in `--world` mode for a five-second runtime smoke test.
- Passed `git diff --check` (line-ending conversion warnings only).