### PR TITLE
Add terrain models and draw distance management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /CMakeCache.txt
 *.user
 *.obj
+!assets/models/*.obj
 *.pdb
 *.ipch
 *.tlog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.25)
-project(WidgeCraft VERSION 0.6.0 LANGUAGES CXX)
+project(WidgeCraft VERSION 0.7.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-option(WIDGECRAFT_BUILD_SANDBOX "Build the WidgeCraft UI sandbox" ON)
+option(WIDGECRAFT_BUILD_SANDBOX "Build the WidgeCraft sandboxes" ON)
 
 include(FetchContent)
 
@@ -48,6 +48,8 @@ endfunction()
 set(WIDGECRAFT_ENGINE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/WidgeCraft.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/input/Input.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/model/Mesh.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/model/ModelLoader.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/physics/Collider.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/physics/PhysicsWorld.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/window/Window.hpp
@@ -57,6 +59,7 @@ set(WIDGECRAFT_ENGINE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/ui/UiScreen.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Scene.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/SceneManager.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/ObjectManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Camera2D.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/Camera3D.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/scene/ModelViewport.hpp
@@ -67,11 +70,15 @@ set(WIDGECRAFT_ENGINE_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/primitives/Shapes2D.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/primitives/Shapes3D.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/primitives/TextRenderer.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/terrain/HeightMap.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/WidgeCraft/terrain/Terrain.hpp
 )
 
 set(WIDGECRAFT_ENGINE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/WidgeCraft.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/input/Input.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/model/Mesh.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/model/ModelLoader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/physics/PhysicsWorld.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/window/Window.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/Frame.cpp
@@ -79,11 +86,14 @@ set(WIDGECRAFT_ENGINE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/UiManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/UiScreen.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scene/SceneManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/scene/ObjectManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scene/Raycast.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/ShaderProgram.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/primitives/Shapes2D.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/primitives/Shapes3D.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/primitives/TextRenderer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/terrain/HeightMap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/terrain/Terrain.cpp
 )
 
 # ---------------- Engine library ----------------
@@ -126,24 +136,32 @@ widgecraft_enable_warnings(widgecraft_engine)
 
 # ---------------- Launchable sandboxes ----------------
 if(WIDGECRAFT_BUILD_SANDBOX)
-    add_executable(widgecraft_ui_sandbox
-        ${CMAKE_CURRENT_SOURCE_DIR}/sandbox/UiDemo.cpp
-    )
-    set_target_properties(widgecraft_ui_sandbox PROPERTIES
-        FOLDER "Sandbox"
-    )
-    target_link_libraries(widgecraft_ui_sandbox PRIVATE WidgeCraft::Engine)
-    widgecraft_enable_warnings(widgecraft_ui_sandbox)
+    function(widgecraft_add_sandbox target source)
+        add_executable(${target} ${source})
+        set_target_properties(${target} PROPERTIES FOLDER "Sandbox")
+        target_link_libraries(${target} PRIVATE WidgeCraft::Engine)
+        widgecraft_enable_warnings(${target})
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${CMAKE_CURRENT_SOURCE_DIR}/assets
+                $<TARGET_FILE_DIR:${target}>/assets
+            COMMENT "Copying WidgeCraft assets for ${target}"
+        )
+    endfunction()
+
+    widgecraft_add_sandbox(
+        widgecraft_ui_sandbox
+        ${CMAKE_CURRENT_SOURCE_DIR}/sandbox/UiDemo.cpp)
+    widgecraft_add_sandbox(
+        widgecraft_terrain_sandbox
+        ${CMAKE_CURRENT_SOURCE_DIR}/sandbox/TerrainSandbox.cpp)
+    widgecraft_add_sandbox(
+        widgecraft_batch_sandbox
+        ${CMAKE_CURRENT_SOURCE_DIR}/sandbox/BatchSandbox.cpp)
 
     set_property(
         DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         PROPERTY VS_STARTUP_PROJECT widgecraft_ui_sandbox
     )
 
-    add_custom_command(TARGET widgecraft_ui_sandbox POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${CMAKE_CURRENT_SOURCE_DIR}/assets
-            $<TARGET_FILE_DIR:widgecraft_ui_sandbox>/assets
-        COMMENT "Copying WidgeCraft assets for UI sandbox"
-    )
 endif()

--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
 # WidgeCraft
 
-WidgeCraft is a Windows-focused C++17/OpenGL 3.3 engine foundation with managed scenes and UI screens, lightweight AABB physics, retained UI, SDF text, batched 2D primitives, basic 3D primitives, independently clipped model viewports and ray queries. The supported development target is Visual Studio 2022, Win32, Release.
+WidgeCraft is a Windows-focused C++17/OpenGL 3.3 engine foundation with managed scenes, objects and UI screens, heightmap terrain, lightweight AABB/heightfield physics, OBJ/STL models, retained UI, SDF text, batched 2D and 3D primitives, independently clipped model viewports and ray queries. The supported development target is Visual Studio 2022, Win32, Release.
 
 ## Project layout
 
 ```text
 include/WidgeCraft/
   input/        Keyboard, mouse and pointer state
-  physics/      Box colliders, bodies, gravity and collision resolution
+  model/        Shared meshes, transforms and OBJ/STL loading
+  physics/      Box/heightfield collision, triggers, bodies and gravity
+  terrain/      PGM heightmaps, gradual generation and terrain meshes
   window/       Window, framebuffer and client-area ownership
   ui/           UI screens, scene views, frames and retained widgets
-  scene/        Scene management, cameras, model viewports and raycasting
+  scene/        Scene/object management, cameras, viewports and raycasting
   render/       Shader-program and rendering-pipeline utilities
   primitives/   Maths/types, Shapes2D, Shapes3D and SDF text
 
 src/
   core/         Application loop and subsystem orchestration
   input/        Input implementation
+  model/        Mesh transforms and model parsers
   physics/      Sub-stepped physics simulation and collision solver
+  terrain/      Height sampling, generation and mesh construction
   window/       Window implementation
   ui/           Frame and widget implementation
   scene/        Scene-query implementation
@@ -100,11 +104,66 @@ WidgeCraft::Ray ray = viewport.screenPointToRay3D(
 
 `drawLabel3D` keeps a projected object label at a fixed pixel size. `drawWorldText3D` creates a camera-facing label whose size is derived from a requested world height.
 
+### Draw distance
+
+`ModelViewport::setDrawDistance` updates the 3D camera far plane. `ObjectManager::setDrawDistance` performs the matching CPU distance test, so out-of-range objects are not transformed, queued or labelled before the GPU clips the view.
+
+```cpp
+viewport.setDrawDistance(80.0f);
+objects.setDrawDistance(80.0f);
+
+const auto stats = objects.render(
+    engine.getShapes3D(),
+    viewport.getCamera3D().getPosition(),
+    &viewport,
+    &engine.getTextRenderer());
+```
+
+`ObjectRenderStats` reports considered, rendered and culled objects, queued triangles and labels, temporary vertex bytes, and CPU queue time.
+
 ## Primitive drawing
 
 `Shapes2D` supports points, thick lines, triangles, rectangles and circles. `ShapeStyle2D` combines fill colour, edge colour and edge thickness.
 
-`Shapes3D` supports lines, triangles, quads, boxes and cubes. `ShapeStyle3D` provides fill and edge styling. The 3D edge thickness uses OpenGL line width and is subject to the graphics driver's supported range.
+`Shapes3D` supports lines, triangles, quads, boxes, cubes and shared `Mesh3D` objects. All filled triangles queued in one viewport pass share one GPU upload/draw. `Shapes2D::drawMesh` does the same for `Mesh2D`. `ShapeStyle3D` provides fill and edge styling. The 3D edge thickness uses OpenGL line width and is subject to the graphics driver's supported range.
+
+## Models and managed objects
+
+`ModelLoader` reads Wavefront OBJ faces (including polygon fan triangulation and negative indices), ASCII STL and binary STL. A loaded 3D mesh can also be projected onto the XY, XZ or YZ plane for batched 2D drawing.
+
+```cpp
+auto mesh = std::make_shared<WidgeCraft::Mesh3D>(
+    WidgeCraft::ModelLoader::load("assets/models/pyramid.obj"));
+
+WidgeCraft::ObjectManager objects(&physics);
+auto& object = objects.createMeshObject("Pyramid", mesh);
+object.setPosition({ 4.0f, 1.0f, -3.0f });
+object.getAttributes().collidable = true;
+object.getAttributes().fixed = true;
+object.getAttributes().labelVisible = true;
+```
+
+Every managed object has `enabled`, `rendered`, `interactable`, `collidable`, `fixed`, `gravity`, `trigger`, `selectable` and `labelVisible` attributes. `preparePhysics()` creates or updates the required bodies before `PhysicsWorld::step`; `syncFromPhysics()` copies dynamic body positions back afterwards. Trigger bodies report overlap in `PhysicsCollision::trigger` without applying collision response.
+
+`raycastInteractable` only considers enabled, interactable/selectable objects. `queryTriggers` provides a physics-independent AABB trigger query, while `getTriggeredObjects` maps current physics trigger overlaps back to object IDs.
+
+## Heightmap terrain
+
+`HeightMap` can load 8-bit P2/P5 PGM files or create reproducible gradual random terrain. The `maximumNeighbourStep` generator argument limits adjacent vertex height changes before optional smoothing.
+
+```cpp
+auto heights = std::make_shared<WidgeCraft::HeightMap>(
+    WidgeCraft::HeightMap::generateGradual(
+        65, 65, 1.0f, 0.58f, 1337, 3,
+        { -32.0f, 0.0f, -32.0f }));
+
+WidgeCraft::Terrain terrain(heights);
+physics.setHeightMapCollider(heights);
+```
+
+The rectangular grid is split into alternating right triangles. A heightmap naturally supplies square rows and columns; alternating the diagonal avoids a consistent directional bias while preserving compact indexing and exact collision sampling. An equilateral layout would require staggered samples and would not map cleanly to ordinary heightmap images.
+
+Dynamic AABB bodies sample the same triangle surface used to render `Terrain`, so gravity, grounded state and jumping work on gradual slopes. `Terrain::draw` also accepts a CPU draw distance for large grids.
 
 ## Physics
 
@@ -127,7 +186,7 @@ auto& player = physics.createBody(
 physics.step(engine.getDeltaTime());
 ```
 
-`PhysicsBody::getBounds()` returns the same world-space `AABB` accepted by `raycast`, so picking and collision can share one authoritative bound. This first physics layer intentionally uses axis-aligned boxes and has no rotational dynamics or mesh colliders yet.
+`PhysicsBody::getBounds()` returns the same world-space `AABB` accepted by `raycast`, so picking and collision can share one authoritative bound. Box bodies remain axis-aligned and do not have rotational dynamics; terrain collision is sampled from the heightmap rather than using a general triangle-mesh solver.
 
 ## Scene and UI
 
@@ -179,7 +238,7 @@ minimap.setRenderCallback([](
 });
 ```
 
-Inactive UI screens do not render or process widget input. The retained UI contains `Frame`, `Label`, `Button` and `Checkbox`, and remains isolated from scene transforms and clipping.
+Inactive UI screens do not render or process widget input. The retained UI contains `Frame`, `Label`, `Button`, `Checkbox` and `Slider`, and remains isolated from scene transforms and clipping.
 
 ## Interactive sandbox controls
 
@@ -212,6 +271,14 @@ build\win32-release\WidgeCraft.sln
 ```
 
 The generated solution sets `widgecraft_ui_sandbox` as the startup project.
+
+Three launchable sandbox projects are available under the solution's `Sandbox` folder:
+
+- `widgecraft_ui_sandbox`: scene/UI switching, camera follow, enemy selection, collision and minimap.
+- `widgecraft_terrain_sandbox`: gradual seeded terrain, WASD movement, heightfield gravity and `Space` jumping.
+- `widgecraft_batch_sandbox`: 1,000 OBJ/STL objects with SDF ID labels, queue/memory statistics and a draw-distance slider. Use WASD and right-drag to move the camera.
+
+To run one in Visual Studio, right-click the sandbox project, choose **Set as Startup Project**, then press `F5` (debug) or `Ctrl+F5` (without the debugger).
 
 ## Build
 

--- a/assets/models/pyramid.obj
+++ b/assets/models/pyramid.obj
@@ -1,0 +1,12 @@
+# WidgeCraft batching sandbox pyramid
+v -1.0 0.0 -1.0
+v  1.0 0.0 -1.0
+v  1.0 0.0  1.0
+v -1.0 0.0  1.0
+v  0.0 2.0  0.0
+
+f 1 4 3 2
+f 1 2 5
+f 2 3 5
+f 3 4 5
+f 4 1 5

--- a/assets/models/tetrahedron.stl
+++ b/assets/models/tetrahedron.stl
@@ -1,0 +1,30 @@
+solid widgecraft_tetrahedron
+  facet normal 0 0 -1
+    outer loop
+      vertex -1 0 -0.7
+      vertex 1 0 -0.7
+      vertex 0 1.8 0
+    endloop
+  endfacet
+  facet normal 1 0 1
+    outer loop
+      vertex 1 0 -0.7
+      vertex 0 0 1
+      vertex 0 1.8 0
+    endloop
+  endfacet
+  facet normal -1 0 1
+    outer loop
+      vertex 0 0 1
+      vertex -1 0 -0.7
+      vertex 0 1.8 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1 0 -0.7
+      vertex 0 0 1
+      vertex 1 0 -0.7
+    endloop
+  endfacet
+endsolid widgecraft_tetrahedron

--- a/include/WidgeCraft/WidgeCraft.hpp
+++ b/include/WidgeCraft/WidgeCraft.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "WidgeCraft/input/Input.hpp"
+#include "WidgeCraft/model/Mesh.hpp"
+#include "WidgeCraft/model/ModelLoader.hpp"
 #include "WidgeCraft/physics/Collider.hpp"
 #include "WidgeCraft/physics/PhysicsWorld.hpp"
 #include "WidgeCraft/primitives/Shapes2D.hpp"
@@ -11,10 +13,13 @@
 #include "WidgeCraft/scene/Camera2D.hpp"
 #include "WidgeCraft/scene/Camera3D.hpp"
 #include "WidgeCraft/scene/ModelViewport.hpp"
+#include "WidgeCraft/scene/ObjectManager.hpp"
 #include "WidgeCraft/scene/Raycast.hpp"
 #include "WidgeCraft/scene/Scene.hpp"
 #include "WidgeCraft/scene/SceneManager.hpp"
 #include "WidgeCraft/scene/SceneViewport2D.hpp"
+#include "WidgeCraft/terrain/HeightMap.hpp"
+#include "WidgeCraft/terrain/Terrain.hpp"
 #include "WidgeCraft/ui/Frame.hpp"
 #include "WidgeCraft/ui/UiManager.hpp"
 #include "WidgeCraft/ui/UiScreen.hpp"

--- a/include/WidgeCraft/model/Mesh.hpp
+++ b/include/WidgeCraft/model/Mesh.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "WidgeCraft/primitives/Types.hpp"
+#include "WidgeCraft/scene/Raycast.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace WidgeCraft {
+
+    struct Transform3D {
+        Vec3 position{};
+        // Euler angles in radians: pitch (x), yaw (y), roll (z).
+        Vec3 rotation{};
+        Vec3 scale{ 1.0f, 1.0f, 1.0f };
+
+        Vec3 transformPoint(const Vec3& point) const;
+    };
+
+    struct Mesh3D {
+        std::vector<Vec3> vertices;
+        std::vector<std::uint32_t> indices;
+
+        bool empty() const {
+            return vertices.empty() || indices.size() < 3;
+        }
+        bool isValid() const;
+        std::size_t getTriangleCount() const {
+            return indices.size() / 3U;
+        }
+        std::size_t getMemoryUsageBytes() const {
+            return vertices.capacity() * sizeof(Vec3)
+                + indices.capacity() * sizeof(std::uint32_t);
+        }
+        AABB getBounds() const;
+    };
+
+    struct Mesh2D {
+        std::vector<Vec2> vertices;
+        std::vector<std::uint32_t> indices;
+
+        bool empty() const {
+            return vertices.empty() || indices.size() < 3;
+        }
+        bool isValid() const;
+        std::size_t getTriangleCount() const {
+            return indices.size() / 3U;
+        }
+    };
+
+    Mesh3D makeBoxMesh(const Vec3& halfExtents);
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/model/ModelLoader.hpp
+++ b/include/WidgeCraft/model/ModelLoader.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "WidgeCraft/model/Mesh.hpp"
+
+#include <filesystem>
+
+namespace WidgeCraft {
+
+    enum class MeshProjectionPlane {
+        XY,
+        XZ,
+        YZ
+    };
+
+    class ModelLoader {
+    public:
+        // Loads Wavefront OBJ or STL based on the file extension.
+        static Mesh3D load(const std::filesystem::path& path);
+        static Mesh3D loadObj(const std::filesystem::path& path);
+        static Mesh3D loadStl(const std::filesystem::path& path);
+
+        // OBJ/STL models can also be projected to a batched 2D triangle mesh.
+        static Mesh2D load2D(
+            const std::filesystem::path& path,
+            MeshProjectionPlane plane = MeshProjectionPlane::XY);
+        static Mesh2D projectTo2D(
+            const Mesh3D& mesh,
+            MeshProjectionPlane plane = MeshProjectionPlane::XY);
+    };
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/physics/PhysicsWorld.hpp
+++ b/include/WidgeCraft/physics/PhysicsWorld.hpp
@@ -2,6 +2,7 @@
 
 #include "WidgeCraft/physics/Collider.hpp"
 #include "WidgeCraft/scene/Raycast.hpp"
+#include "WidgeCraft/terrain/HeightMap.hpp"
 
 #include <cstdint>
 #include <memory>
@@ -48,6 +49,14 @@ namespace WidgeCraft {
         void setEnabled(bool enabled) { m_enabled = enabled; }
         bool isEnabled() const { return m_enabled; }
 
+        void setCollisionEnabled(bool enabled) {
+            m_collisionEnabled = enabled;
+        }
+        bool isCollisionEnabled() const { return m_collisionEnabled; }
+
+        void setTrigger(bool trigger) { m_trigger = trigger; }
+        bool isTrigger() const { return m_trigger; }
+
     private:
         friend class PhysicsWorld;
 
@@ -68,6 +77,8 @@ namespace WidgeCraft {
         float m_gravityScale = 1.0f;
         bool m_grounded = false;
         bool m_enabled = true;
+        bool m_collisionEnabled = true;
+        bool m_trigger = false;
     };
 
     struct PhysicsCollision {
@@ -76,6 +87,7 @@ namespace WidgeCraft {
         // Points from the second body towards the first body.
         Vec3 normal{};
         float penetration = 0.0f;
+        bool trigger = false;
     };
 
     class PhysicsWorld {
@@ -100,6 +112,16 @@ namespace WidgeCraft {
         void setSolverIterations(int iterations);
         int getSolverIterations() const { return m_solverIterations; }
 
+        // Adds a triangle-sampled heightfield beneath dynamic AABB bodies.
+        // Passing nullptr removes terrain collision.
+        void setHeightMapCollider(
+            std::shared_ptr<const HeightMap> heightMap) {
+            m_heightMapCollider = std::move(heightMap);
+        }
+        std::shared_ptr<const HeightMap> getHeightMapCollider() const {
+            return m_heightMapCollider;
+        }
+
         void step(float deltaTime);
 
         const std::vector<std::unique_ptr<PhysicsBody>>& getBodies() const {
@@ -112,9 +134,15 @@ namespace WidgeCraft {
     private:
         void integrate(float deltaTime);
         void solveCollisions();
+        void solveHeightMapCollisions();
         void recordCollision(
             const PhysicsBody& first,
             const PhysicsBody& second,
+            const Vec3& normal,
+            float penetration,
+            bool trigger);
+        void recordHeightMapCollision(
+            const PhysicsBody& body,
             const Vec3& normal,
             float penetration);
         PhysicsBodyId allocateId();
@@ -122,6 +150,7 @@ namespace WidgeCraft {
         Vec3 m_gravity{ 0.0f, -18.0f, 0.0f };
         std::vector<std::unique_ptr<PhysicsBody>> m_bodies;
         std::vector<PhysicsCollision> m_collisions;
+        std::shared_ptr<const HeightMap> m_heightMapCollider;
         PhysicsBodyId m_nextId = 1;
         float m_maximumStep = 1.0f / 120.0f;
         int m_solverIterations = 4;

--- a/include/WidgeCraft/primitives/Shapes2D.hpp
+++ b/include/WidgeCraft/primitives/Shapes2D.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "WidgeCraft/model/Mesh.hpp"
 #include "WidgeCraft/primitives/Types.hpp"
 
 #include <cstddef>
@@ -107,7 +108,17 @@ namespace WidgeCraft {
             }
         }
 
+        void drawMesh(
+            const Mesh2D& mesh,
+            const Vec2& position = {},
+            float rotationRadians = 0.0f,
+            const Vec2& scale = { 1.0f, 1.0f },
+            const ShapeStyle2D& style = ShapeStyle2D{});
+
         std::size_t getQueuedTriangleCount() const { return m_vertices.size() / 3; }
+        std::size_t getQueuedVertexBytes() const {
+            return m_vertices.size() * sizeof(Vertex);
+        }
 
     private:
         struct Vertex {

--- a/include/WidgeCraft/primitives/Shapes3D.hpp
+++ b/include/WidgeCraft/primitives/Shapes3D.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "WidgeCraft/model/Mesh.hpp"
 #include "WidgeCraft/primitives/Types.hpp"
 #include "WidgeCraft/render/ShaderProgram.hpp"
 
@@ -66,12 +67,20 @@ namespace WidgeCraft {
             const Vec3& center,
             float size,
             const ShapeStyle3D& style = ShapeStyle3D{});
+        void drawMesh(
+            const Mesh3D& mesh,
+            const Transform3D& transform = {},
+            const ShapeStyle3D& style = ShapeStyle3D{});
 
         std::size_t getQueuedTriangleCount() const {
             return m_triangles.size() / 3;
         }
         std::size_t getQueuedLineCount() const {
             return m_lines.size();
+        }
+        std::size_t getQueuedVertexBytes() const {
+            return m_triangles.size() * sizeof(Vertex)
+                + m_lines.size() * sizeof(LineCommand);
         }
 
     private:

--- a/include/WidgeCraft/primitives/TextRenderer.hpp
+++ b/include/WidgeCraft/primitives/TextRenderer.hpp
@@ -53,6 +53,9 @@ namespace WidgeCraft {
         float getDescent() const { return m_descent; }
         float getBasePixelHeight() const { return m_basePixelHeight; }
         std::size_t getQueuedGlyphCount() const { return m_vertices.size() / 6; }
+        std::size_t getQueuedVertexBytes() const {
+            return m_vertices.size() * sizeof(float) * 8U;
+        }
 
     private:
         struct Glyph {

--- a/include/WidgeCraft/scene/Camera3D.hpp
+++ b/include/WidgeCraft/scene/Camera3D.hpp
@@ -59,6 +59,12 @@ namespace WidgeCraft {
 
         float getNearPlane() const { return m_nearPlane; }
         float getFarPlane() const { return m_farPlane; }
+        void setNearPlane(float nearPlane) {
+            setDepthRange(nearPlane, m_farPlane);
+        }
+        void setFarPlane(float farPlane) {
+            setDepthRange(m_nearPlane, farPlane);
+        }
         float getVerticalFieldOfViewDegrees() const {
             return m_verticalFieldOfViewDegrees;
         }

--- a/include/WidgeCraft/scene/ModelViewport.hpp
+++ b/include/WidgeCraft/scene/ModelViewport.hpp
@@ -50,6 +50,15 @@ namespace WidgeCraft {
         Camera3D& getCamera3D() { return m_camera3D; }
         const Camera3D& getCamera3D() const { return m_camera3D; }
 
+        // Draw distance is the camera far plane. Pair it with ObjectManager's
+        // CPU culling distance to avoid queuing objects that the GPU will clip.
+        void setDrawDistance(float distance) {
+            m_camera3D.setFarPlane(distance);
+        }
+        float getDrawDistance() const {
+            return m_camera3D.getFarPlane();
+        }
+
         Vec2 worldToScreen2D(const Vec2& worldPosition) const {
             return m_camera2D.worldToScreen(worldPosition, m_screenRect);
         }

--- a/include/WidgeCraft/scene/ObjectManager.hpp
+++ b/include/WidgeCraft/scene/ObjectManager.hpp
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "WidgeCraft/model/Mesh.hpp"
+#include "WidgeCraft/physics/PhysicsWorld.hpp"
+#include "WidgeCraft/primitives/Shapes3D.hpp"
+#include "WidgeCraft/primitives/TextRenderer.hpp"
+#include "WidgeCraft/scene/ModelViewport.hpp"
+#include "WidgeCraft/scene/Raycast.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace WidgeCraft {
+
+    using ObjectId = std::uint64_t;
+
+    struct ObjectAttributes {
+        bool enabled = true;
+        bool rendered = true;
+        bool interactable = true;
+        bool collidable = false;
+        bool fixed = true;
+        bool gravity = false;
+        bool trigger = false;
+        bool selectable = true;
+        bool labelVisible = false;
+    };
+
+    struct ObjectRenderStats {
+        std::size_t considered = 0;
+        std::size_t rendered = 0;
+        std::size_t distanceCulled = 0;
+        std::size_t hidden = 0;
+        std::size_t trianglesQueued = 0;
+        std::size_t labelsQueued = 0;
+        std::size_t vertexBytesQueued = 0;
+        double cpuMilliseconds = 0.0;
+    };
+
+    struct ObjectRayHit {
+        ObjectId objectId = 0;
+        RayHit hit{};
+    };
+
+    class SceneObject {
+    public:
+        ObjectId getId() const { return m_id; }
+        const std::string& getName() const { return m_name; }
+        void setName(std::string name) { m_name = std::move(name); }
+
+        const Transform3D& getTransform() const { return m_transform; }
+        void setTransform(const Transform3D& transform);
+        void setPosition(const Vec3& position);
+        void setRotation(const Vec3& rotation);
+        void setScale(const Vec3& scale);
+
+        ObjectAttributes& getAttributes() { return m_attributes; }
+        const ObjectAttributes& getAttributes() const {
+            return m_attributes;
+        }
+
+        void setMesh(std::shared_ptr<const Mesh3D> mesh);
+        std::shared_ptr<const Mesh3D> getMesh() const { return m_mesh; }
+
+        ShapeStyle3D& getStyle() { return m_style; }
+        const ShapeStyle3D& getStyle() const { return m_style; }
+
+        AABB getWorldBounds() const;
+        PhysicsBodyId getPhysicsBodyId() const {
+            return m_physicsBodyId;
+        }
+
+    private:
+        friend class ObjectManager;
+
+        SceneObject(
+            ObjectId id,
+            std::string name,
+            std::shared_ptr<const Mesh3D> mesh,
+            const Transform3D& transform);
+
+        ObjectId m_id = 0;
+        std::string m_name;
+        std::shared_ptr<const Mesh3D> m_mesh;
+        Transform3D m_transform;
+        ShapeStyle3D m_style;
+        ObjectAttributes m_attributes;
+        PhysicsBodyId m_physicsBodyId = 0;
+        bool m_transformDirty = true;
+    };
+
+    class ObjectManager {
+    public:
+        explicit ObjectManager(PhysicsWorld* physicsWorld = nullptr)
+            : m_physicsWorld(physicsWorld) {
+        }
+
+        SceneObject& createMeshObject(
+            std::string name,
+            std::shared_ptr<const Mesh3D> mesh,
+            const Transform3D& transform = {},
+            ObjectId requestedId = 0);
+        SceneObject& createBoxObject(
+            std::string name,
+            const Vec3& halfExtents,
+            const Transform3D& transform = {},
+            ObjectId requestedId = 0);
+
+        SceneObject* find(ObjectId id);
+        const SceneObject* find(ObjectId id) const;
+        bool remove(ObjectId id);
+        void clear();
+
+        const std::vector<std::unique_ptr<SceneObject>>& getObjects() const {
+            return m_objects;
+        }
+        std::size_t getObjectCount() const { return m_objects.size(); }
+
+        void setDrawDistance(float distance);
+        float getDrawDistance() const { return m_drawDistance; }
+
+        ObjectRenderStats render(
+            Shapes3D& shapes,
+            const Vec3& viewPosition,
+            const ModelViewport* viewport = nullptr,
+            TextRenderer* textRenderer = nullptr) const;
+
+        bool raycastInteractable(
+            const Ray& ray,
+            ObjectRayHit& result,
+            float maximumDistance = 0.0f) const;
+        std::vector<ObjectId> queryTriggers(const AABB& bounds) const;
+
+        void setPhysicsWorld(PhysicsWorld* physicsWorld);
+        PhysicsWorld* getPhysicsWorld() const { return m_physicsWorld; }
+        void preparePhysics();
+        void syncFromPhysics();
+        PhysicsBody* getPhysicsBody(SceneObject& object);
+        const PhysicsBody* getPhysicsBody(const SceneObject& object) const;
+        std::vector<ObjectId> getTriggeredObjects(
+            PhysicsBodyId otherBodyId) const;
+
+        std::size_t getApproximateMemoryUsageBytes() const;
+
+    private:
+        ObjectId allocateId();
+        void detachPhysics(SceneObject& object);
+
+        std::vector<std::unique_ptr<SceneObject>> m_objects;
+        PhysicsWorld* m_physicsWorld = nullptr;
+        ObjectId m_nextId = 1;
+        float m_drawDistance = 1000.0f;
+    };
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/terrain/HeightMap.hpp
+++ b/include/WidgeCraft/terrain/HeightMap.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "WidgeCraft/primitives/Types.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+namespace WidgeCraft {
+
+    class HeightMap {
+    public:
+        HeightMap() = default;
+        HeightMap(
+            std::size_t width,
+            std::size_t depth,
+            float cellSize,
+            std::vector<float> heights,
+            const Vec3& origin = {});
+
+        static HeightMap loadPgm(
+            const std::filesystem::path& path,
+            float cellSize = 1.0f,
+            float heightScale = 1.0f,
+            float heightOffset = 0.0f,
+            const Vec3& origin = {});
+
+        static HeightMap generateGradual(
+            std::size_t width,
+            std::size_t depth,
+            float cellSize,
+            float maximumNeighbourStep,
+            std::uint32_t seed = 0,
+            int smoothingPasses = 3,
+            const Vec3& origin = {});
+
+        bool empty() const { return m_heights.empty(); }
+        std::size_t getWidth() const { return m_width; }
+        std::size_t getDepth() const { return m_depth; }
+        float getCellSize() const { return m_cellSize; }
+        Vec3 getOrigin() const { return m_origin; }
+
+        float getHeight(std::size_t x, std::size_t z) const;
+        void setHeight(std::size_t x, std::size_t z, float height);
+        const std::vector<float>& getHeights() const { return m_heights; }
+
+        float getWorldWidth() const;
+        float getWorldDepth() const;
+        bool contains(float worldX, float worldZ) const;
+
+        // Samples the exact alternating-triangle surface used by Terrain.
+        std::optional<float> sampleHeight(
+            float worldX,
+            float worldZ) const;
+        std::optional<Vec3> sampleNormal(
+            float worldX,
+            float worldZ) const;
+
+    private:
+        std::size_t index(std::size_t x, std::size_t z) const;
+        void validate() const;
+
+        std::size_t m_width = 0;
+        std::size_t m_depth = 0;
+        float m_cellSize = 1.0f;
+        Vec3 m_origin{};
+        std::vector<float> m_heights;
+    };
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/terrain/Terrain.hpp
+++ b/include/WidgeCraft/terrain/Terrain.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "WidgeCraft/model/Mesh.hpp"
+#include "WidgeCraft/primitives/Shapes3D.hpp"
+#include "WidgeCraft/terrain/HeightMap.hpp"
+
+#include <memory>
+
+namespace WidgeCraft {
+
+    class Terrain {
+    public:
+        explicit Terrain(std::shared_ptr<HeightMap> heightMap);
+
+        std::shared_ptr<HeightMap> getHeightMap() { return m_heightMap; }
+        std::shared_ptr<const HeightMap> getHeightMap() const {
+            return m_heightMap;
+        }
+        const Mesh3D& getMesh() const { return m_mesh; }
+
+        void rebuildMesh();
+        void draw(
+            Shapes3D& shapes,
+            const ShapeStyle3D& style,
+            const Vec3& viewPosition = {},
+            float drawDistance = 0.0f) const;
+
+    private:
+        std::shared_ptr<HeightMap> m_heightMap;
+        Mesh3D m_mesh;
+    };
+
+} // namespace WidgeCraft

--- a/include/WidgeCraft/ui/Widget.hpp
+++ b/include/WidgeCraft/ui/Widget.hpp
@@ -194,6 +194,56 @@ namespace WidgeCraft {
         ChangeCallback m_onChanged;
     };
 
+    class Slider : public Widget {
+    public:
+        using ChangeCallback = std::function<void(float)>;
+
+        Slider(
+            std::string name,
+            float minimum = 0.0f,
+            float maximum = 1.0f,
+            float value = 0.0f);
+
+        void setRange(float minimum, float maximum);
+        float getMinimum() const { return m_minimum; }
+        float getMaximum() const { return m_maximum; }
+
+        void setValue(float value);
+        float getValue() const { return m_value; }
+
+        void setStep(float step) { m_step = std::max(step, 0.0f); }
+        float getStep() const { return m_step; }
+
+        void setTrackColor(Color color) { m_trackColor = color; }
+        void setFillColor(Color color) { m_fillColor = color; }
+        void setThumbColor(Color color) { m_thumbColor = color; }
+        void setOnChanged(ChangeCallback callback) {
+            m_onChanged = std::move(callback);
+        }
+
+        bool isDragging() const { return m_dragging; }
+
+        void render(
+            Frame& frame,
+            TextRenderer& textRenderer,
+            ShapeRenderer& shapeRenderer,
+            const Input& input) override;
+
+    private:
+        float quantize(float value) const;
+        void setValueFromPointer(float pointerX, const Rect& track);
+
+        float m_minimum = 0.0f;
+        float m_maximum = 1.0f;
+        float m_value = 0.0f;
+        float m_step = 0.0f;
+        bool m_dragging = false;
+        Color m_trackColor{ 0.13f, 0.18f, 0.24f, 1.0f };
+        Color m_fillColor{ 0.18f, 0.58f, 0.82f, 1.0f };
+        Color m_thumbColor{ 0.78f, 0.92f, 1.0f, 1.0f };
+        ChangeCallback m_onChanged;
+    };
+
     template <typename T, typename... Args>
     T& Widgets::emplace(Args&&... args) {
         auto widget = std::make_unique<T>(std::forward<Args>(args)...);

--- a/sandbox/BatchSandbox.cpp
+++ b/sandbox/BatchSandbox.cpp
@@ -1,0 +1,268 @@
+#include "WidgeCraft/WidgeCraft.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <exception>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace {
+
+    class BatchDemo {
+    public:
+        explicit BatchDemo(WidgeCraft::WidgeCraft& app) {
+            const std::filesystem::path modelDirectory =
+                std::filesystem::path(WIDGECRAFT_ASSET_DIR) / "models";
+            m_pyramid = std::make_shared<WidgeCraft::Mesh3D>(
+                WidgeCraft::ModelLoader::load(
+                    modelDirectory / "pyramid.obj"));
+            m_tetrahedron = std::make_shared<WidgeCraft::Mesh3D>(
+                WidgeCraft::ModelLoader::load(
+                    modelDirectory / "tetrahedron.stl"));
+
+            constexpr int columns = 40;
+            constexpr int rows = 25;
+            constexpr float spacing = 4.0f;
+            for (int row = 0; row < rows; ++row) {
+                for (int column = 0; column < columns; ++column) {
+                    const int index = row * columns + column;
+                    WidgeCraft::Transform3D transform;
+                    transform.position = {
+                        (static_cast<float>(column)
+                            - static_cast<float>(columns - 1) * 0.5f)
+                            * spacing,
+                        0.9f + 0.45f * std::sin(
+                            static_cast<float>(index) * 0.17f),
+                        (static_cast<float>(row)
+                            - static_cast<float>(rows - 1) * 0.5f)
+                            * spacing
+                    };
+                    transform.rotation.y = static_cast<float>(index) * 0.13f;
+                    transform.scale = { 0.8f, 0.8f, 0.8f };
+
+                    auto& object = m_objects.createMeshObject(
+                        "Stress object " + std::to_string(index + 1),
+                        index % 2 == 0 ? m_pyramid : m_tetrahedron,
+                        transform);
+                    object.getAttributes().labelVisible = true;
+                    object.getAttributes().interactable = false;
+                    object.getStyle().edgeVisible = false;
+                    object.getStyle().fillColor = index % 2 == 0
+                        ? WidgeCraft::Color{ 0.15f, 0.50f, 0.84f, 1.0f }
+                        : WidgeCraft::Color{ 0.82f, 0.34f, 0.16f, 1.0f };
+                }
+            }
+            m_objects.setDrawDistance(m_drawDistance);
+
+            auto& camera = m_viewport.getCamera3D();
+            camera.setPerspective(55.0f, 0.1f, m_drawDistance);
+            updateCamera();
+
+            auto& panel = app.getRootFrame().createChildFrame("Batch HUD");
+            panel.setAnchor(WidgeCraft::Anchor::TopLeft);
+            panel.setPosition(20.0f, 20.0f);
+            panel.setSize(620.0f, 214.0f);
+            panel.setBackgroundColor({ 0.025f, 0.038f, 0.060f, 0.94f });
+            panel.setBorderVisible(true);
+            panel.setBorderColor({ 0.30f, 0.58f, 0.82f, 1.0f });
+            panel.setBorderThickness(2.0f);
+
+            auto& title = panel.addWidget<WidgeCraft::Label>(
+                "Title",
+                "1,000-object batch and label stress test");
+            title.setAnchor(WidgeCraft::Anchor::TopLeft);
+            title.setPosition(16.0f, 12.0f);
+            title.setTextSize(23.0f);
+            title.setColor({ 0.76f, 0.92f, 1.0f, 1.0f });
+
+            m_distanceLabel = &panel.addWidget<WidgeCraft::Label>(
+                "Distance",
+                "Draw distance: 55");
+            m_distanceLabel->setAnchor(WidgeCraft::Anchor::TopLeft);
+            m_distanceLabel->setPosition(16.0f, 50.0f);
+            m_distanceLabel->setTextSize(16.0f);
+
+            auto& slider = panel.addWidget<WidgeCraft::Slider>(
+                "Draw Distance",
+                12.0f,
+                180.0f,
+                m_drawDistance);
+            slider.setAnchor(WidgeCraft::Anchor::TopLeft);
+            slider.setPosition(16.0f, 78.0f);
+            slider.setSize(580.0f, 32.0f);
+            slider.setStep(1.0f);
+            slider.setOnChanged([this](float distance) {
+                m_drawDistance = distance;
+                m_objects.setDrawDistance(distance);
+                m_viewport.setDrawDistance(distance);
+                m_distanceLabel->setText(
+                    "Draw distance: "
+                    + std::to_string(static_cast<int>(distance)));
+            });
+
+            m_statsLabel = &panel.addWidget<WidgeCraft::Label>(
+                "Stats",
+                "Collecting batch statistics...");
+            m_statsLabel->setAnchor(WidgeCraft::Anchor::BottomLeft);
+            m_statsLabel->setPosition(16.0f, 48.0f);
+            m_statsLabel->setTextSize(15.0f);
+            m_statsLabel->setColor({ 0.64f, 0.88f, 0.72f, 1.0f });
+
+            m_memoryLabel = &panel.addWidget<WidgeCraft::Label>(
+                "Memory",
+                "Scene memory");
+            m_memoryLabel->setAnchor(WidgeCraft::Anchor::BottomLeft);
+            m_memoryLabel->setPosition(16.0f, 18.0f);
+            m_memoryLabel->setTextSize(15.0f);
+            m_memoryLabel->setColor({ 0.68f, 0.78f, 0.90f, 1.0f });
+        }
+
+        void update(WidgeCraft::WidgeCraft& app) {
+            setViewport(app);
+            const auto& input = app.getInput();
+            if (input.mouseDown(WidgeCraft::MouseButton::Right)) {
+                const WidgeCraft::Vec2 delta = input.mouseDelta();
+                m_yaw += delta.x * 0.005f;
+                m_pitch = std::clamp(
+                    m_pitch + delta.y * 0.005f,
+                    -0.95f,
+                    0.65f);
+            }
+
+            const WidgeCraft::Vec3 forward{
+                std::sin(m_yaw),
+                0.0f,
+                -std::cos(m_yaw)
+            };
+            const WidgeCraft::Vec3 right{
+                std::cos(m_yaw),
+                0.0f,
+                std::sin(m_yaw)
+            };
+            WidgeCraft::Vec3 movement{};
+            if (input.keyDown(WidgeCraft::Key::W)) {
+                movement += forward;
+            }
+            if (input.keyDown(WidgeCraft::Key::S)) {
+                movement -= forward;
+            }
+            if (input.keyDown(WidgeCraft::Key::D)) {
+                movement += right;
+            }
+            if (input.keyDown(WidgeCraft::Key::A)) {
+                movement -= right;
+            }
+            if (WidgeCraft::lengthSquared(movement) > 1.0f) {
+                movement = WidgeCraft::normalized(movement);
+            }
+            m_cameraTarget += movement
+                * (24.0f * app.getDeltaTime());
+            updateCamera();
+
+            std::ostringstream stats;
+            stats << std::fixed << std::setprecision(3)
+                  << "Visible " << m_stats.rendered << " / 1000"
+                  << "  |  culled " << m_stats.distanceCulled
+                  << "  |  labels " << m_stats.labelsQueued
+                  << "  |  CPU queue " << m_stats.cpuMilliseconds << " ms";
+            m_statsLabel->setText(stats.str());
+
+            const double sceneMegabytes = static_cast<double>(
+                m_objects.getApproximateMemoryUsageBytes())
+                / (1024.0 * 1024.0);
+            const double queueKilobytes = static_cast<double>(
+                m_stats.vertexBytesQueued)
+                / 1024.0;
+            std::ostringstream memory;
+            memory << std::fixed << std::setprecision(2)
+                   << "Triangles " << m_stats.trianglesQueued
+                   << "  |  vertex queue " << queueKilobytes << " KiB"
+                   << "  |  scene " << sceneMegabytes << " MiB"
+                   << "  |  1 mesh draw + 1 SDF text draw";
+            m_memoryLabel->setText(memory.str());
+        }
+
+        void render(WidgeCraft::WidgeCraft& app) {
+            setViewport(app);
+            updateCamera();
+
+            WidgeCraft::ViewportRenderOptions options;
+            options.clearColor = true;
+            options.color = { 0.018f, 0.026f, 0.042f, 1.0f };
+            app.renderViewport(
+                m_viewport,
+                [this](WidgeCraft::WidgeCraft& engine) {
+                    m_stats = m_objects.render(
+                        engine.getShapes3D(),
+                        m_viewport.getCamera3D().getPosition(),
+                        &m_viewport,
+                        &engine.getTextRenderer());
+                },
+                options);
+        }
+
+    private:
+        void setViewport(WidgeCraft::WidgeCraft& app) {
+            m_viewport.setScreenRect({
+                0.0f,
+                0.0f,
+                static_cast<float>(app.getWindow().getWidth()),
+                static_cast<float>(app.getWindow().getHeight())
+            });
+        }
+
+        void updateCamera() {
+            const float horizontal = std::cos(m_pitch) * 24.0f;
+            const WidgeCraft::Vec3 offset{
+                horizontal * std::sin(m_yaw),
+                11.0f + std::sin(m_pitch) * 24.0f,
+                horizontal * std::cos(m_yaw)
+            };
+            auto& camera = m_viewport.getCamera3D();
+            camera.setPosition(m_cameraTarget + offset);
+            camera.setTarget(m_cameraTarget);
+        }
+
+        std::shared_ptr<WidgeCraft::Mesh3D> m_pyramid;
+        std::shared_ptr<WidgeCraft::Mesh3D> m_tetrahedron;
+        WidgeCraft::ObjectManager m_objects;
+        WidgeCraft::ObjectRenderStats m_stats;
+        WidgeCraft::ModelViewport m_viewport;
+        WidgeCraft::Label* m_distanceLabel = nullptr;
+        WidgeCraft::Label* m_statsLabel = nullptr;
+        WidgeCraft::Label* m_memoryLabel = nullptr;
+        WidgeCraft::Vec3 m_cameraTarget{};
+        float m_drawDistance = 55.0f;
+        float m_yaw = 0.0f;
+        float m_pitch = -0.22f;
+    };
+
+} // namespace
+
+int main() {
+    try {
+        WidgeCraft::WidgeCraft app(
+            "WidgeCraft Batch and Draw Distance Sandbox",
+            1280,
+            800);
+        BatchDemo demo(app);
+        app.setUpdateCallback(
+            [&demo](WidgeCraft::WidgeCraft& engine) {
+                demo.update(engine);
+            });
+        app.setRenderCallback(
+            [&demo](WidgeCraft::WidgeCraft& engine) {
+                demo.render(engine);
+            });
+        app.Run(60);
+    } catch (const std::exception& exception) {
+        std::cerr << "WidgeCraft batch sandbox failed: "
+                  << exception.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/sandbox/TerrainSandbox.cpp
+++ b/sandbox/TerrainSandbox.cpp
@@ -1,0 +1,284 @@
+#include "WidgeCraft/WidgeCraft.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <exception>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace {
+
+    class TerrainDemo {
+    public:
+        explicit TerrainDemo(WidgeCraft::WidgeCraft& app)
+            : m_heightMap(std::make_shared<WidgeCraft::HeightMap>(
+                WidgeCraft::HeightMap::generateGradual(
+                    65,
+                    65,
+                    1.0f,
+                    0.58f,
+                    1337,
+                    3,
+                    { -32.0f, 0.0f, -32.0f })))
+            , m_terrain(m_heightMap) {
+
+            m_physics.setGravity({ 0.0f, -20.0f, 0.0f });
+            m_physics.setHeightMapCollider(m_heightMap);
+            const float startHeight = m_heightMap->sampleHeight(0.0f, 0.0f)
+                .value_or(0.0f);
+            m_player = &m_physics.createBody(
+                WidgeCraft::PhysicsBodyType::Dynamic,
+                { 0.0f, startHeight + PlayerHalfHeight, 0.0f },
+                WidgeCraft::BoxCollider({
+                    PlayerHalfWidth,
+                    PlayerHalfHeight,
+                    PlayerHalfWidth
+                }));
+            m_player->setMass(1.0f);
+
+            auto& camera = m_viewport.getCamera3D();
+            camera.setPerspective(55.0f, 0.1f, DrawDistance);
+            updateCamera();
+
+            auto& panel = app.getRootFrame().createChildFrame("Terrain HUD");
+            panel.setAnchor(WidgeCraft::Anchor::TopLeft);
+            panel.setPosition(20.0f, 20.0f);
+            panel.setSize(560.0f, 136.0f);
+            panel.setBackgroundColor({ 0.025f, 0.045f, 0.055f, 0.92f });
+            panel.setBorderVisible(true);
+            panel.setBorderColor({ 0.30f, 0.68f, 0.54f, 1.0f });
+            panel.setBorderThickness(2.0f);
+
+            auto& title = panel.addWidget<WidgeCraft::Label>(
+                "Title",
+                "Gradual heightmap terrain");
+            title.setAnchor(WidgeCraft::Anchor::TopLeft);
+            title.setPosition(16.0f, 12.0f);
+            title.setTextSize(23.0f);
+            title.setColor({ 0.72f, 1.0f, 0.82f, 1.0f });
+
+            auto& help = panel.addWidget<WidgeCraft::Label>(
+                "Help",
+                "WASD move  |  Space jump  |  Right-drag look  |  Wheel zoom");
+            help.setAnchor(WidgeCraft::Anchor::TopLeft);
+            help.setPosition(16.0f, 48.0f);
+            help.setTextSize(15.0f);
+            help.setColor({ 0.72f, 0.82f, 0.86f, 1.0f });
+
+            m_status = &panel.addWidget<WidgeCraft::Label>(
+                "Status",
+                "Initialising terrain physics...");
+            m_status->setAnchor(WidgeCraft::Anchor::BottomLeft);
+            m_status->setPosition(16.0f, 18.0f);
+            m_status->setTextSize(16.0f);
+            m_status->setColor({ 0.58f, 0.92f, 0.68f, 1.0f });
+        }
+
+        void update(WidgeCraft::WidgeCraft& app) {
+            setViewport(app);
+            const float deltaTime = app.getDeltaTime();
+            const auto& input = app.getInput();
+
+            m_cameraDistance = std::clamp(
+                m_cameraDistance - input.scrollDelta().y * 1.1f,
+                2.5f,
+                14.0f);
+            if (input.mouseDown(WidgeCraft::MouseButton::Right)) {
+                const WidgeCraft::Vec2 delta = input.mouseDelta();
+                m_yaw += delta.x * 0.006f;
+                m_pitch = std::clamp(
+                    m_pitch + delta.y * 0.006f,
+                    -1.0f,
+                    0.55f);
+            }
+
+            const WidgeCraft::Vec3 forward{
+                std::sin(m_yaw),
+                0.0f,
+                -std::cos(m_yaw)
+            };
+            const WidgeCraft::Vec3 right{
+                std::cos(m_yaw),
+                0.0f,
+                std::sin(m_yaw)
+            };
+            WidgeCraft::Vec3 movement{};
+            if (input.keyDown(WidgeCraft::Key::W)) {
+                movement += forward;
+            }
+            if (input.keyDown(WidgeCraft::Key::S)) {
+                movement -= forward;
+            }
+            if (input.keyDown(WidgeCraft::Key::D)) {
+                movement += right;
+            }
+            if (input.keyDown(WidgeCraft::Key::A)) {
+                movement -= right;
+            }
+            if (WidgeCraft::lengthSquared(movement) > 1.0f) {
+                movement = WidgeCraft::normalized(movement);
+            }
+
+            WidgeCraft::Vec3 velocity = m_player->getVelocity();
+            velocity.x = movement.x * MovementSpeed;
+            velocity.z = movement.z * MovementSpeed;
+            if (input.keyPressed(WidgeCraft::Key::Space)
+                && m_player->isGrounded()) {
+                velocity.y = JumpVelocity;
+            }
+            m_player->setVelocity(velocity);
+            m_physics.step(deltaTime);
+
+            if (m_player->getPosition().y < -20.0f) {
+                const float resetHeight = m_heightMap->sampleHeight(0.0f, 0.0f)
+                    .value_or(0.0f);
+                m_player->setPosition({
+                    0.0f,
+                    resetHeight + PlayerHalfHeight + 0.1f,
+                    0.0f
+                });
+                m_player->setVelocity({});
+            }
+
+            updateCamera();
+            std::ostringstream status;
+            status << std::fixed << std::setprecision(2)
+                   << "Position " << m_player->getPosition().x
+                   << ", " << m_player->getPosition().y
+                   << ", " << m_player->getPosition().z
+                   << "  |  "
+                   << (m_player->isGrounded() ? "Grounded" : "Airborne")
+                   << "  |  8,192 batched terrain triangles";
+            m_status->setText(status.str());
+        }
+
+        void render(WidgeCraft::WidgeCraft& app) {
+            setViewport(app);
+            updateCamera();
+
+            WidgeCraft::ViewportRenderOptions options;
+            options.clearColor = true;
+            options.color = { 0.035f, 0.065f, 0.080f, 1.0f };
+            app.renderViewport(
+                m_viewport,
+                [this](WidgeCraft::WidgeCraft& engine) {
+                    WidgeCraft::ShapeStyle3D terrainStyle;
+                    terrainStyle.fillColor = {
+                        0.18f,
+                        0.48f,
+                        0.25f,
+                        1.0f
+                    };
+                    terrainStyle.edgeVisible = false;
+                    m_terrain.draw(
+                        engine.getShapes3D(),
+                        terrainStyle,
+                        m_player->getPosition(),
+                        DrawDistance);
+
+                    WidgeCraft::ShapeStyle3D playerStyle;
+                    playerStyle.fillColor = {
+                        0.12f,
+                        0.52f,
+                        0.88f,
+                        1.0f
+                    };
+                    playerStyle.edgeColor = {
+                        0.76f,
+                        0.94f,
+                        1.0f,
+                        1.0f
+                    };
+                    playerStyle.edgeThickness = 2.0f;
+                    const WidgeCraft::AABB bounds = m_player->getBounds();
+                    engine.getShapes3D().drawBox(
+                        bounds.minimum,
+                        bounds.maximum,
+                        playerStyle);
+                },
+                options);
+        }
+
+    private:
+        void setViewport(WidgeCraft::WidgeCraft& app) {
+            m_viewport.setScreenRect({
+                0.0f,
+                0.0f,
+                static_cast<float>(app.getWindow().getWidth()),
+                static_cast<float>(app.getWindow().getHeight())
+            });
+        }
+
+        WidgeCraft::Vec3 viewForward() const {
+            const float pitchScale = std::cos(m_pitch);
+            return WidgeCraft::normalized({
+                pitchScale * std::sin(m_yaw),
+                std::sin(m_pitch),
+                -pitchScale * std::cos(m_yaw)
+            });
+        }
+
+        void updateCamera() {
+            const WidgeCraft::Vec3 eye = m_player->getPosition()
+                + WidgeCraft::Vec3{ 0.0f, 0.62f, 0.0f };
+            const WidgeCraft::Vec3 forward = viewForward();
+            WidgeCraft::Vec3 cameraPosition = eye
+                - forward * m_cameraDistance;
+            const auto terrainHeight = m_heightMap->sampleHeight(
+                cameraPosition.x,
+                cameraPosition.z);
+            if (terrainHeight) {
+                cameraPosition.y = std::max(
+                    cameraPosition.y,
+                    *terrainHeight + 0.4f);
+            }
+            auto& camera = m_viewport.getCamera3D();
+            camera.setPosition(cameraPosition);
+            camera.setTarget(eye);
+        }
+
+        static constexpr float PlayerHalfWidth = 0.42f;
+        static constexpr float PlayerHalfHeight = 0.85f;
+        static constexpr float MovementSpeed = 6.0f;
+        static constexpr float JumpVelocity = 8.5f;
+        static constexpr float DrawDistance = 72.0f;
+
+        std::shared_ptr<WidgeCraft::HeightMap> m_heightMap;
+        WidgeCraft::Terrain m_terrain;
+        WidgeCraft::PhysicsWorld m_physics;
+        WidgeCraft::PhysicsBody* m_player = nullptr;
+        WidgeCraft::ModelViewport m_viewport;
+        WidgeCraft::Label* m_status = nullptr;
+        float m_yaw = 0.0f;
+        float m_pitch = -0.34f;
+        float m_cameraDistance = 10.0f;
+    };
+
+} // namespace
+
+int main() {
+    try {
+        WidgeCraft::WidgeCraft app(
+            "WidgeCraft Heightmap Terrain Sandbox",
+            1200,
+            760);
+        TerrainDemo demo(app);
+        app.setUpdateCallback(
+            [&demo](WidgeCraft::WidgeCraft& engine) {
+                demo.update(engine);
+            });
+        app.setRenderCallback(
+            [&demo](WidgeCraft::WidgeCraft& engine) {
+                demo.render(engine);
+            });
+        app.Run(60);
+    } catch (const std::exception& exception) {
+        std::cerr << "WidgeCraft terrain sandbox failed: "
+                  << exception.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/src/model/Mesh.cpp
+++ b/src/model/Mesh.cpp
@@ -1,0 +1,114 @@
+#include "WidgeCraft/model/Mesh.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace WidgeCraft {
+
+    Vec3 Transform3D::transformPoint(const Vec3& point) const {
+        Vec3 result{
+            point.x * scale.x,
+            point.y * scale.y,
+            point.z * scale.z
+        };
+
+        const float cosX = std::cos(rotation.x);
+        const float sinX = std::sin(rotation.x);
+        result = {
+            result.x,
+            result.y * cosX - result.z * sinX,
+            result.y * sinX + result.z * cosX
+        };
+
+        const float cosY = std::cos(rotation.y);
+        const float sinY = std::sin(rotation.y);
+        result = {
+            result.x * cosY + result.z * sinY,
+            result.y,
+            -result.x * sinY + result.z * cosY
+        };
+
+        const float cosZ = std::cos(rotation.z);
+        const float sinZ = std::sin(rotation.z);
+        result = {
+            result.x * cosZ - result.y * sinZ,
+            result.x * sinZ + result.y * cosZ,
+            result.z
+        };
+        return result + position;
+    }
+
+    bool Mesh3D::isValid() const {
+        if (empty() || indices.size() % 3U != 0U) {
+            return false;
+        }
+        return std::all_of(
+            indices.begin(),
+            indices.end(),
+            [this](std::uint32_t index) {
+                return index < vertices.size();
+            });
+    }
+
+    AABB Mesh3D::getBounds() const {
+        if (vertices.empty()) {
+            return {};
+        }
+
+        const float maximum = std::numeric_limits<float>::max();
+        Vec3 minimum{ maximum, maximum, maximum };
+        Vec3 upper{ -maximum, -maximum, -maximum };
+        for (const Vec3& vertex : vertices) {
+            minimum.x = std::min(minimum.x, vertex.x);
+            minimum.y = std::min(minimum.y, vertex.y);
+            minimum.z = std::min(minimum.z, vertex.z);
+            upper.x = std::max(upper.x, vertex.x);
+            upper.y = std::max(upper.y, vertex.y);
+            upper.z = std::max(upper.z, vertex.z);
+        }
+        return { minimum, upper };
+    }
+
+    bool Mesh2D::isValid() const {
+        if (empty() || indices.size() % 3U != 0U) {
+            return false;
+        }
+        return std::all_of(
+            indices.begin(),
+            indices.end(),
+            [this](std::uint32_t index) {
+                return index < vertices.size();
+            });
+    }
+
+    Mesh3D makeBoxMesh(const Vec3& halfExtentsValue) {
+        const Vec3 half{
+            std::max(std::abs(halfExtentsValue.x), 0.001f),
+            std::max(std::abs(halfExtentsValue.y), 0.001f),
+            std::max(std::abs(halfExtentsValue.z), 0.001f)
+        };
+
+        Mesh3D mesh;
+        mesh.vertices = {
+            { -half.x, -half.y, -half.z },
+            {  half.x, -half.y, -half.z },
+            {  half.x,  half.y, -half.z },
+            { -half.x,  half.y, -half.z },
+            { -half.x, -half.y,  half.z },
+            {  half.x, -half.y,  half.z },
+            {  half.x,  half.y,  half.z },
+            { -half.x,  half.y,  half.z }
+        };
+        mesh.indices = {
+            0, 3, 2, 0, 2, 1,
+            4, 5, 6, 4, 6, 7,
+            0, 4, 7, 0, 7, 3,
+            1, 2, 6, 1, 6, 5,
+            0, 1, 5, 0, 5, 4,
+            3, 7, 6, 3, 6, 2
+        };
+        return mesh;
+    }
+
+} // namespace WidgeCraft

--- a/src/model/ModelLoader.cpp
+++ b/src/model/ModelLoader.cpp
@@ -1,0 +1,275 @@
+#include "WidgeCraft/model/ModelLoader.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace WidgeCraft {
+
+    namespace {
+        std::string lowercase(std::string value) {
+            std::transform(
+                value.begin(),
+                value.end(),
+                value.begin(),
+                [](unsigned char character) {
+                    return static_cast<char>(std::tolower(character));
+                });
+            return value;
+        }
+
+        std::uint32_t resolveObjIndex(
+            const std::string& token,
+            std::size_t vertexCount) {
+
+            const std::size_t slash = token.find('/');
+            const std::string positionToken = token.substr(0, slash);
+            if (positionToken.empty()) {
+                throw std::runtime_error(
+                    "OBJ face is missing a position index");
+            }
+
+            const int rawIndex = std::stoi(positionToken);
+            if (rawIndex == 0) {
+                throw std::runtime_error("OBJ indices are one-based");
+            }
+
+            const long long resolved = rawIndex > 0
+                ? static_cast<long long>(rawIndex - 1)
+                : static_cast<long long>(vertexCount) + rawIndex;
+            if (resolved < 0
+                || resolved >= static_cast<long long>(vertexCount)) {
+                throw std::runtime_error(
+                    "OBJ face references a vertex outside the model");
+            }
+            return static_cast<std::uint32_t>(resolved);
+        }
+
+        std::vector<unsigned char> readBinaryFile(
+            const std::filesystem::path& path) {
+
+            std::ifstream stream(path, std::ios::binary | std::ios::ate);
+            if (!stream) {
+                throw std::runtime_error(
+                    "Unable to open model file: " + path.string());
+            }
+
+            const std::streamsize size = stream.tellg();
+            if (size < 0) {
+                throw std::runtime_error(
+                    "Unable to determine model file size: " + path.string());
+            }
+            stream.seekg(0, std::ios::beg);
+
+            std::vector<unsigned char> bytes(
+                static_cast<std::size_t>(size));
+            if (!bytes.empty()
+                && !stream.read(
+                    reinterpret_cast<char*>(bytes.data()),
+                    size)) {
+                throw std::runtime_error(
+                    "Unable to read model file: " + path.string());
+            }
+            return bytes;
+        }
+
+        std::uint32_t readUint32(
+            const std::vector<unsigned char>& bytes,
+            std::size_t offset) {
+
+            std::uint32_t value = 0;
+            std::memcpy(&value, bytes.data() + offset, sizeof(value));
+            return value;
+        }
+
+        float readFloat(
+            const std::vector<unsigned char>& bytes,
+            std::size_t offset) {
+
+            float value = 0.0f;
+            std::memcpy(&value, bytes.data() + offset, sizeof(value));
+            return value;
+        }
+
+        bool isBinaryStl(const std::vector<unsigned char>& bytes) {
+            if (bytes.size() < 84U) {
+                return false;
+            }
+            const std::uint32_t triangleCount = readUint32(bytes, 80U);
+            const std::uint64_t expectedSize = 84ULL
+                + static_cast<std::uint64_t>(triangleCount) * 50ULL;
+            return expectedSize == bytes.size();
+        }
+    } // namespace
+
+    Mesh3D ModelLoader::load(const std::filesystem::path& path) {
+        const std::string extension = lowercase(path.extension().string());
+        if (extension == ".obj") {
+            return loadObj(path);
+        }
+        if (extension == ".stl") {
+            return loadStl(path);
+        }
+        throw std::invalid_argument(
+            "Unsupported model format '" + extension
+            + "'; expected .obj or .stl");
+    }
+
+    Mesh3D ModelLoader::loadObj(const std::filesystem::path& path) {
+        std::ifstream stream(path);
+        if (!stream) {
+            throw std::runtime_error(
+                "Unable to open OBJ file: " + path.string());
+        }
+
+        Mesh3D mesh;
+        std::string line;
+        std::size_t lineNumber = 0;
+        while (std::getline(stream, line)) {
+            ++lineNumber;
+            std::istringstream parser(line);
+            std::string command;
+            parser >> command;
+            if (command.empty() || command[0] == '#') {
+                continue;
+            }
+
+            if (command == "v") {
+                Vec3 vertex;
+                if (!(parser >> vertex.x >> vertex.y >> vertex.z)) {
+                    throw std::runtime_error(
+                        "Invalid OBJ vertex at line "
+                        + std::to_string(lineNumber));
+                }
+                mesh.vertices.push_back(vertex);
+                continue;
+            }
+
+            if (command == "f") {
+                std::vector<std::uint32_t> face;
+                std::string token;
+                while (parser >> token) {
+                    face.push_back(resolveObjIndex(
+                        token,
+                        mesh.vertices.size()));
+                }
+                if (face.size() < 3U) {
+                    throw std::runtime_error(
+                        "OBJ face has fewer than three vertices at line "
+                        + std::to_string(lineNumber));
+                }
+                for (std::size_t index = 1;
+                     index + 1U < face.size();
+                     ++index) {
+                    mesh.indices.push_back(face[0]);
+                    mesh.indices.push_back(face[index]);
+                    mesh.indices.push_back(face[index + 1U]);
+                }
+            }
+        }
+
+        if (!mesh.isValid()) {
+            throw std::runtime_error(
+                "OBJ contains no valid triangle mesh: " + path.string());
+        }
+        return mesh;
+    }
+
+    Mesh3D ModelLoader::loadStl(const std::filesystem::path& path) {
+        const std::vector<unsigned char> bytes = readBinaryFile(path);
+        Mesh3D mesh;
+
+        if (isBinaryStl(bytes)) {
+            const std::uint32_t triangleCount = readUint32(bytes, 80U);
+            mesh.vertices.reserve(
+                static_cast<std::size_t>(triangleCount) * 3U);
+            mesh.indices.reserve(
+                static_cast<std::size_t>(triangleCount) * 3U);
+
+            for (std::uint32_t triangle = 0;
+                 triangle < triangleCount;
+                 ++triangle) {
+                const std::size_t record = 84U
+                    + static_cast<std::size_t>(triangle) * 50U;
+                for (std::size_t vertex = 0; vertex < 3U; ++vertex) {
+                    const std::size_t offset = record + 12U + vertex * 12U;
+                    mesh.vertices.push_back({
+                        readFloat(bytes, offset),
+                        readFloat(bytes, offset + 4U),
+                        readFloat(bytes, offset + 8U)
+                    });
+                    mesh.indices.push_back(
+                        static_cast<std::uint32_t>(mesh.indices.size()));
+                }
+            }
+        } else {
+            const std::string text(bytes.begin(), bytes.end());
+            std::istringstream stream(text);
+            std::string line;
+            while (std::getline(stream, line)) {
+                std::istringstream parser(line);
+                std::string command;
+                parser >> command;
+                if (lowercase(command) != "vertex") {
+                    continue;
+                }
+                Vec3 vertex;
+                if (!(parser >> vertex.x >> vertex.y >> vertex.z)) {
+                    throw std::runtime_error(
+                        "Invalid vertex in ASCII STL: " + path.string());
+                }
+                mesh.vertices.push_back(vertex);
+                mesh.indices.push_back(
+                    static_cast<std::uint32_t>(mesh.indices.size()));
+            }
+        }
+
+        if (!mesh.isValid()) {
+            throw std::runtime_error(
+                "STL contains no valid triangles: " + path.string());
+        }
+        return mesh;
+    }
+
+    Mesh2D ModelLoader::load2D(
+        const std::filesystem::path& path,
+        MeshProjectionPlane plane) {
+        return projectTo2D(load(path), plane);
+    }
+
+    Mesh2D ModelLoader::projectTo2D(
+        const Mesh3D& mesh,
+        MeshProjectionPlane plane) {
+
+        if (!mesh.isValid()) {
+            throw std::invalid_argument(
+                "Cannot project an invalid 3D mesh");
+        }
+
+        Mesh2D result;
+        result.indices = mesh.indices;
+        result.vertices.reserve(mesh.vertices.size());
+        for (const Vec3& vertex : mesh.vertices) {
+            switch (plane) {
+            case MeshProjectionPlane::XZ:
+                result.vertices.push_back({ vertex.x, vertex.z });
+                break;
+            case MeshProjectionPlane::YZ:
+                result.vertices.push_back({ vertex.y, vertex.z });
+                break;
+            case MeshProjectionPlane::XY:
+            default:
+                result.vertices.push_back({ vertex.x, vertex.y });
+                break;
+            }
+        }
+        return result;
+    }
+
+} // namespace WidgeCraft

--- a/src/physics/PhysicsWorld.cpp
+++ b/src/physics/PhysicsWorld.cpp
@@ -169,6 +169,7 @@ namespace WidgeCraft {
     void PhysicsWorld::clear() {
         m_bodies.clear();
         m_collisions.clear();
+        m_heightMapCollider.reset();
         m_nextId = 1;
     }
 
@@ -224,7 +225,9 @@ namespace WidgeCraft {
              firstIndex < m_bodies.size();
              ++firstIndex) {
             PhysicsBody* first = m_bodies[firstIndex].get();
-            if (!first || !first->isEnabled()) {
+            if (!first
+                || !first->isEnabled()
+                || !first->isCollisionEnabled()) {
                 continue;
             }
 
@@ -232,7 +235,9 @@ namespace WidgeCraft {
                  secondIndex < m_bodies.size();
                  ++secondIndex) {
                 PhysicsBody* second = m_bodies[secondIndex].get();
-                if (!second || !second->isEnabled()) {
+                if (!second
+                    || !second->isEnabled()
+                    || !second->isCollisionEnabled()) {
                     continue;
                 }
 
@@ -240,7 +245,9 @@ namespace WidgeCraft {
                 const float secondInverseMass = second->inverseMass();
                 const float inverseMassSum =
                     firstInverseMass + secondInverseMass;
-                if (inverseMassSum <= 0.0f) {
+                if (inverseMassSum <= 0.0f
+                    && !first->isTrigger()
+                    && !second->isTrigger()) {
                     continue;
                 }
 
@@ -251,6 +258,18 @@ namespace WidgeCraft {
                         *second,
                         normal,
                         penetration)) {
+                    continue;
+                }
+
+                const bool trigger = first->isTrigger()
+                    || second->isTrigger();
+                if (trigger) {
+                    recordCollision(
+                        *first,
+                        *second,
+                        normal,
+                        penetration,
+                        true);
                     continue;
                 }
 
@@ -283,8 +302,72 @@ namespace WidgeCraft {
                     *first,
                     *second,
                     normal,
-                    penetration);
+                    penetration,
+                    false);
             }
+        }
+        solveHeightMapCollisions();
+    }
+
+    void PhysicsWorld::solveHeightMapCollisions() {
+        if (!m_heightMapCollider || m_heightMapCollider->empty()) {
+            return;
+        }
+
+        for (auto& bodyPointer : m_bodies) {
+            PhysicsBody* body = bodyPointer.get();
+            if (!body
+                || !body->isEnabled()
+                || !body->isDynamic()
+                || !body->isCollisionEnabled()
+                || body->isTrigger()) {
+                continue;
+            }
+
+            const AABB bounds = body->getBounds();
+            const float centerX = (bounds.minimum.x + bounds.maximum.x)
+                * 0.5f;
+            const float centerZ = (bounds.minimum.z + bounds.maximum.z)
+                * 0.5f;
+            const float inset = 0.01f;
+            const Vec2 samples[] = {
+                { centerX, centerZ },
+                { bounds.minimum.x + inset, bounds.minimum.z + inset },
+                { bounds.maximum.x - inset, bounds.minimum.z + inset },
+                { bounds.minimum.x + inset, bounds.maximum.z - inset },
+                { bounds.maximum.x - inset, bounds.maximum.z - inset }
+            };
+
+            bool foundGround = false;
+            float groundHeight = -std::numeric_limits<float>::max();
+            Vec2 groundPoint{ centerX, centerZ };
+            for (const Vec2& sample : samples) {
+                const auto height = m_heightMapCollider->sampleHeight(
+                    sample.x,
+                    sample.y);
+                if (height && *height > groundHeight) {
+                    foundGround = true;
+                    groundHeight = *height;
+                    groundPoint = sample;
+                }
+            }
+
+            if (!foundGround || bounds.minimum.y >= groundHeight) {
+                continue;
+            }
+
+            const float penetration = groundHeight - bounds.minimum.y;
+            body->m_position.y += penetration;
+            if (body->m_velocity.y < 0.0f) {
+                body->m_velocity.y = 0.0f;
+            }
+            body->m_grounded = true;
+
+            const Vec3 normal = m_heightMapCollider->sampleNormal(
+                groundPoint.x,
+                groundPoint.y)
+                .value_or(Vec3{ 0.0f, 1.0f, 0.0f });
+            recordHeightMapCollision(*body, normal, penetration);
         }
     }
 
@@ -292,14 +375,16 @@ namespace WidgeCraft {
         const PhysicsBody& first,
         const PhysicsBody& second,
         const Vec3& normal,
-        float penetration) {
+        float penetration,
+        bool trigger) {
 
         const auto iterator = std::find_if(
             m_collisions.begin(),
             m_collisions.end(),
             [&](const PhysicsCollision& collision) {
                 return collision.firstBody == first.getId()
-                    && collision.secondBody == second.getId();
+                    && collision.secondBody == second.getId()
+                    && collision.trigger == trigger;
             });
         if (iterator != m_collisions.end()) {
             if (penetration > iterator->penetration) {
@@ -312,7 +397,36 @@ namespace WidgeCraft {
             first.getId(),
             second.getId(),
             normal,
-            penetration
+            penetration,
+            trigger
+        });
+    }
+
+    void PhysicsWorld::recordHeightMapCollision(
+        const PhysicsBody& body,
+        const Vec3& normal,
+        float penetration) {
+
+        const auto iterator = std::find_if(
+            m_collisions.begin(),
+            m_collisions.end(),
+            [&](const PhysicsCollision& collision) {
+                return collision.firstBody == body.getId()
+                    && collision.secondBody == 0;
+            });
+        if (iterator != m_collisions.end()) {
+            if (penetration > iterator->penetration) {
+                iterator->normal = normal;
+                iterator->penetration = penetration;
+            }
+            return;
+        }
+        m_collisions.push_back({
+            body.getId(),
+            0,
+            normal,
+            penetration,
+            false
         });
     }
 

--- a/src/primitives/Shapes2D.cpp
+++ b/src/primitives/Shapes2D.cpp
@@ -220,6 +220,38 @@ namespace WidgeCraft {
         addVertex(c, color);
     }
 
+    void ShapeRenderer::drawMesh(
+        const Mesh2D& mesh,
+        const Vec2& position,
+        float rotationRadians,
+        const Vec2& scale,
+        const ShapeStyle2D& style) {
+
+        if (!mesh.isValid()) {
+            return;
+        }
+
+        const float cosine = std::cos(rotationRadians);
+        const float sine = std::sin(rotationRadians);
+        const auto transformPoint = [&](const Vec2& point) {
+            const Vec2 scaled{ point.x * scale.x, point.y * scale.y };
+            return Vec2{
+                scaled.x * cosine - scaled.y * sine + position.x,
+                scaled.x * sine + scaled.y * cosine + position.y
+            };
+        };
+
+        for (std::size_t index = 0;
+             index + 2U < mesh.indices.size();
+             index += 3U) {
+            drawTriangle(
+                transformPoint(mesh.vertices[mesh.indices[index]]),
+                transformPoint(mesh.vertices[mesh.indices[index + 1U]]),
+                transformPoint(mesh.vertices[mesh.indices[index + 2U]]),
+                style);
+        }
+    }
+
     void ShapeRenderer::drawFilledRect(float x, float y, float width, float height, const Color& color) {
         if (width <= 0.0f || height <= 0.0f) {
             return;

--- a/src/primitives/Shapes3D.cpp
+++ b/src/primitives/Shapes3D.cpp
@@ -275,6 +275,28 @@ namespace WidgeCraft {
         drawBox(center - half, center + half, style);
     }
 
+    void Shapes3D::drawMesh(
+        const Mesh3D& mesh,
+        const Transform3D& transform,
+        const ShapeStyle3D& style) {
+
+        if (!mesh.isValid()) {
+            return;
+        }
+
+        for (std::size_t index = 0;
+             index + 2U < mesh.indices.size();
+             index += 3U) {
+            const Vec3 a = transform.transformPoint(
+                mesh.vertices[mesh.indices[index]]);
+            const Vec3 b = transform.transformPoint(
+                mesh.vertices[mesh.indices[index + 1U]]);
+            const Vec3 c = transform.transformPoint(
+                mesh.vertices[mesh.indices[index + 2U]]);
+            drawTriangle(a, b, c, style);
+        }
+    }
+
     Shapes3D::Vertex Shapes3D::makeVertex(
         const Vec3& position,
         const Color& color) {

--- a/src/scene/ObjectManager.cpp
+++ b/src/scene/ObjectManager.cpp
@@ -1,0 +1,476 @@
+#include "WidgeCraft/scene/ObjectManager.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <unordered_set>
+#include <utility>
+
+namespace WidgeCraft {
+
+    namespace {
+        bool overlaps(const AABB& first, const AABB& second) {
+            return first.minimum.x <= second.maximum.x
+                && first.maximum.x >= second.minimum.x
+                && first.minimum.y <= second.maximum.y
+                && first.maximum.y >= second.minimum.y
+                && first.minimum.z <= second.maximum.z
+                && first.maximum.z >= second.minimum.z;
+        }
+
+        Vec3 sanitizeScale(const Vec3& scale) {
+            const auto component = [](float value) {
+                if (std::abs(value) >= 0.0001f) {
+                    return value;
+                }
+                return value < 0.0f ? -0.0001f : 0.0001f;
+            };
+            return {
+                component(scale.x),
+                component(scale.y),
+                component(scale.z)
+            };
+        }
+    } // namespace
+
+    SceneObject::SceneObject(
+        ObjectId id,
+        std::string name,
+        std::shared_ptr<const Mesh3D> mesh,
+        const Transform3D& transform)
+        : m_id(id)
+        , m_name(std::move(name))
+        , m_mesh(std::move(mesh))
+        , m_transform(transform) {
+        m_transform.scale = sanitizeScale(m_transform.scale);
+    }
+
+    void SceneObject::setTransform(const Transform3D& transform) {
+        m_transform = transform;
+        m_transform.scale = sanitizeScale(m_transform.scale);
+        m_transformDirty = true;
+    }
+
+    void SceneObject::setPosition(const Vec3& position) {
+        m_transform.position = position;
+        m_transformDirty = true;
+    }
+
+    void SceneObject::setRotation(const Vec3& rotation) {
+        m_transform.rotation = rotation;
+        m_transformDirty = true;
+    }
+
+    void SceneObject::setScale(const Vec3& scale) {
+        m_transform.scale = sanitizeScale(scale);
+        m_transformDirty = true;
+    }
+
+    void SceneObject::setMesh(std::shared_ptr<const Mesh3D> mesh) {
+        if (!mesh || !mesh->isValid()) {
+            throw std::invalid_argument(
+                "Scene objects require a valid triangle mesh");
+        }
+        m_mesh = std::move(mesh);
+        m_transformDirty = true;
+    }
+
+    AABB SceneObject::getWorldBounds() const {
+        if (!m_mesh || m_mesh->vertices.empty()) {
+            return { m_transform.position, m_transform.position };
+        }
+
+        const float maximum = std::numeric_limits<float>::max();
+        Vec3 minimum{ maximum, maximum, maximum };
+        Vec3 upper{ -maximum, -maximum, -maximum };
+        for (const Vec3& vertex : m_mesh->vertices) {
+            const Vec3 world = m_transform.transformPoint(vertex);
+            minimum.x = std::min(minimum.x, world.x);
+            minimum.y = std::min(minimum.y, world.y);
+            minimum.z = std::min(minimum.z, world.z);
+            upper.x = std::max(upper.x, world.x);
+            upper.y = std::max(upper.y, world.y);
+            upper.z = std::max(upper.z, world.z);
+        }
+        return { minimum, upper };
+    }
+
+    SceneObject& ObjectManager::createMeshObject(
+        std::string name,
+        std::shared_ptr<const Mesh3D> mesh,
+        const Transform3D& transform,
+        ObjectId requestedId) {
+
+        if (!mesh || !mesh->isValid()) {
+            throw std::invalid_argument(
+                "ObjectManager requires a valid triangle mesh");
+        }
+        const ObjectId id = requestedId == 0
+            ? allocateId()
+            : requestedId;
+        if (find(id)) {
+            throw std::invalid_argument(
+                "An object with the requested ID already exists");
+        }
+        m_nextId = std::max(m_nextId, id + 1U);
+
+        auto object = std::unique_ptr<SceneObject>(new SceneObject(
+            id,
+            std::move(name),
+            std::move(mesh),
+            transform));
+        SceneObject& reference = *object;
+        m_objects.emplace_back(std::move(object));
+        return reference;
+    }
+
+    SceneObject& ObjectManager::createBoxObject(
+        std::string name,
+        const Vec3& halfExtents,
+        const Transform3D& transform,
+        ObjectId requestedId) {
+        return createMeshObject(
+            std::move(name),
+            std::make_shared<Mesh3D>(makeBoxMesh(halfExtents)),
+            transform,
+            requestedId);
+    }
+
+    SceneObject* ObjectManager::find(ObjectId id) {
+        const auto iterator = std::find_if(
+            m_objects.begin(),
+            m_objects.end(),
+            [id](const auto& object) {
+                return object && object->getId() == id;
+            });
+        return iterator != m_objects.end() ? iterator->get() : nullptr;
+    }
+
+    const SceneObject* ObjectManager::find(ObjectId id) const {
+        const auto iterator = std::find_if(
+            m_objects.begin(),
+            m_objects.end(),
+            [id](const auto& object) {
+                return object && object->getId() == id;
+            });
+        return iterator != m_objects.end() ? iterator->get() : nullptr;
+    }
+
+    bool ObjectManager::remove(ObjectId id) {
+        const auto iterator = std::find_if(
+            m_objects.begin(),
+            m_objects.end(),
+            [id](const auto& object) {
+                return object && object->getId() == id;
+            });
+        if (iterator == m_objects.end()) {
+            return false;
+        }
+        detachPhysics(**iterator);
+        m_objects.erase(iterator);
+        return true;
+    }
+
+    void ObjectManager::clear() {
+        if (m_physicsWorld) {
+            for (auto& object : m_objects) {
+                if (object) {
+                    detachPhysics(*object);
+                }
+            }
+        }
+        m_objects.clear();
+        m_nextId = 1;
+    }
+
+    void ObjectManager::setDrawDistance(float distance) {
+        m_drawDistance = std::max(distance, 0.001f);
+    }
+
+    ObjectRenderStats ObjectManager::render(
+        Shapes3D& shapes,
+        const Vec3& viewPosition,
+        const ModelViewport* viewport,
+        TextRenderer* textRenderer) const {
+
+        const auto start = std::chrono::steady_clock::now();
+        ObjectRenderStats stats;
+        const float drawDistanceSquared = m_drawDistance * m_drawDistance;
+
+        for (const auto& objectPointer : m_objects) {
+            const SceneObject* object = objectPointer.get();
+            if (!object) {
+                continue;
+            }
+            ++stats.considered;
+
+            const ObjectAttributes& attributes = object->getAttributes();
+            if (!attributes.enabled || !attributes.rendered) {
+                ++stats.hidden;
+                continue;
+            }
+
+            const Vec3 delta = object->getTransform().position - viewPosition;
+            if (lengthSquared(delta) > drawDistanceSquared) {
+                ++stats.distanceCulled;
+                continue;
+            }
+
+            const std::shared_ptr<const Mesh3D> mesh = object->getMesh();
+            if (!mesh || !mesh->isValid()) {
+                ++stats.hidden;
+                continue;
+            }
+
+            shapes.drawMesh(
+                *mesh,
+                object->getTransform(),
+                object->getStyle());
+            ++stats.rendered;
+            stats.trianglesQueued += mesh->getTriangleCount();
+
+            if (attributes.labelVisible && viewport && textRenderer) {
+                const AABB bounds = object->getWorldBounds();
+                if (viewport->drawLabel3D(
+                        *textRenderer,
+                        "ID " + std::to_string(object->getId()),
+                        {
+                            (bounds.minimum.x + bounds.maximum.x) * 0.5f,
+                            bounds.maximum.y + 0.25f,
+                            (bounds.minimum.z + bounds.maximum.z) * 0.5f
+                        },
+                        13.0f,
+                        { 0.82f, 0.92f, 1.0f, 0.92f })) {
+                    ++stats.labelsQueued;
+                }
+            }
+        }
+
+        stats.vertexBytesQueued = shapes.getQueuedVertexBytes();
+        const auto end = std::chrono::steady_clock::now();
+        stats.cpuMilliseconds = std::chrono::duration<
+            double,
+            std::milli>(end - start).count();
+        return stats;
+    }
+
+    bool ObjectManager::raycastInteractable(
+        const Ray& ray,
+        ObjectRayHit& result,
+        float maximumDistance) const {
+
+        float nearestDistance = maximumDistance > 0.0f
+            ? maximumDistance
+            : std::numeric_limits<float>::max();
+        bool found = false;
+        for (const auto& objectPointer : m_objects) {
+            const SceneObject* object = objectPointer.get();
+            if (!object) {
+                continue;
+            }
+            const ObjectAttributes& attributes = object->getAttributes();
+            if (!attributes.enabled
+                || !attributes.interactable
+                || !attributes.selectable) {
+                continue;
+            }
+
+            RayHit hit;
+            if (raycast(ray, object->getWorldBounds(), hit)
+                && hit.distance < nearestDistance) {
+                nearestDistance = hit.distance;
+                result = { object->getId(), hit };
+                found = true;
+            }
+        }
+        return found;
+    }
+
+    std::vector<ObjectId> ObjectManager::queryTriggers(
+        const AABB& bounds) const {
+
+        std::vector<ObjectId> result;
+        for (const auto& objectPointer : m_objects) {
+            const SceneObject* object = objectPointer.get();
+            if (object
+                && object->getAttributes().enabled
+                && object->getAttributes().trigger
+                && overlaps(bounds, object->getWorldBounds())) {
+                result.push_back(object->getId());
+            }
+        }
+        return result;
+    }
+
+    void ObjectManager::setPhysicsWorld(PhysicsWorld* physicsWorld) {
+        if (m_physicsWorld == physicsWorld) {
+            return;
+        }
+        if (m_physicsWorld) {
+            for (auto& object : m_objects) {
+                if (object) {
+                    detachPhysics(*object);
+                }
+            }
+        }
+        m_physicsWorld = physicsWorld;
+    }
+
+    void ObjectManager::preparePhysics() {
+        if (!m_physicsWorld) {
+            return;
+        }
+
+        for (auto& objectPointer : m_objects) {
+            SceneObject* object = objectPointer.get();
+            if (!object) {
+                continue;
+            }
+            const ObjectAttributes& attributes = object->getAttributes();
+            const bool needsBody = attributes.enabled
+                && (attributes.collidable
+                    || attributes.trigger
+                    || attributes.gravity);
+            if (!needsBody) {
+                detachPhysics(*object);
+                continue;
+            }
+
+            PhysicsBody* body = getPhysicsBody(*object);
+            bool created = false;
+            if (!body) {
+                body = &m_physicsWorld->createBody(
+                    attributes.fixed
+                        ? PhysicsBodyType::Static
+                        : PhysicsBodyType::Dynamic,
+                    object->getTransform().position);
+                object->m_physicsBodyId = body->getId();
+                created = true;
+            }
+
+            body->setType(
+                attributes.fixed
+                    ? PhysicsBodyType::Static
+                    : PhysicsBodyType::Dynamic);
+            body->setEnabled(attributes.enabled);
+            body->setCollisionEnabled(
+                attributes.collidable || attributes.trigger);
+            body->setTrigger(attributes.trigger);
+            body->setGravityScale(attributes.gravity ? 1.0f : 0.0f);
+
+            const AABB bounds = object->getWorldBounds();
+            const Vec3 center = (bounds.minimum + bounds.maximum) * 0.5f;
+            const Vec3 half = (bounds.maximum - bounds.minimum) * 0.5f;
+            body->setCollider(BoxCollider(
+                half,
+                center - object->getTransform().position));
+
+            if (created || attributes.fixed || object->m_transformDirty) {
+                body->setPosition(object->getTransform().position);
+                object->m_transformDirty = false;
+            }
+        }
+    }
+
+    void ObjectManager::syncFromPhysics() {
+        if (!m_physicsWorld) {
+            return;
+        }
+        for (auto& objectPointer : m_objects) {
+            SceneObject* object = objectPointer.get();
+            if (!object || object->getAttributes().fixed) {
+                continue;
+            }
+            const PhysicsBody* body = getPhysicsBody(*object);
+            if (body) {
+                object->m_transform.position = body->getPosition();
+                object->m_transformDirty = false;
+            }
+        }
+    }
+
+    PhysicsBody* ObjectManager::getPhysicsBody(SceneObject& object) {
+        return m_physicsWorld && object.m_physicsBodyId != 0
+            ? m_physicsWorld->findBody(object.m_physicsBodyId)
+            : nullptr;
+    }
+
+    const PhysicsBody* ObjectManager::getPhysicsBody(
+        const SceneObject& object) const {
+        return m_physicsWorld && object.m_physicsBodyId != 0
+            ? m_physicsWorld->findBody(object.m_physicsBodyId)
+            : nullptr;
+    }
+
+    std::vector<ObjectId> ObjectManager::getTriggeredObjects(
+        PhysicsBodyId otherBodyId) const {
+
+        std::vector<ObjectId> result;
+        if (!m_physicsWorld) {
+            return result;
+        }
+        for (const PhysicsCollision& collision
+             : m_physicsWorld->getCollisions()) {
+            if (!collision.trigger) {
+                continue;
+            }
+
+            PhysicsBodyId triggerBody = 0;
+            if (collision.firstBody == otherBodyId) {
+                triggerBody = collision.secondBody;
+            } else if (collision.secondBody == otherBodyId) {
+                triggerBody = collision.firstBody;
+            } else {
+                continue;
+            }
+
+            const auto iterator = std::find_if(
+                m_objects.begin(),
+                m_objects.end(),
+                [triggerBody](const auto& object) {
+                    return object
+                        && object->m_physicsBodyId == triggerBody
+                        && object->getAttributes().trigger;
+                });
+            if (iterator != m_objects.end()) {
+                result.push_back((*iterator)->getId());
+            }
+        }
+        return result;
+    }
+
+    std::size_t ObjectManager::getApproximateMemoryUsageBytes() const {
+        std::size_t bytes = m_objects.capacity()
+            * sizeof(std::unique_ptr<SceneObject>);
+        std::unordered_set<const Mesh3D*> meshes;
+        for (const auto& object : m_objects) {
+            if (!object) {
+                continue;
+            }
+            bytes += sizeof(SceneObject) + object->m_name.capacity();
+            if (object->m_mesh
+                && meshes.insert(object->m_mesh.get()).second) {
+                bytes += sizeof(Mesh3D)
+                    + object->m_mesh->getMemoryUsageBytes();
+            }
+        }
+        return bytes;
+    }
+
+    ObjectId ObjectManager::allocateId() {
+        while (find(m_nextId)) {
+            ++m_nextId;
+        }
+        return m_nextId++;
+    }
+
+    void ObjectManager::detachPhysics(SceneObject& object) {
+        if (m_physicsWorld && object.m_physicsBodyId != 0) {
+            m_physicsWorld->removeBody(object.m_physicsBodyId);
+        }
+        object.m_physicsBodyId = 0;
+    }
+
+} // namespace WidgeCraft

--- a/src/terrain/HeightMap.cpp
+++ b/src/terrain/HeightMap.cpp
@@ -1,0 +1,394 @@
+#include "WidgeCraft/terrain/HeightMap.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <random>
+#include <stdexcept>
+#include <string>
+
+namespace WidgeCraft {
+
+    namespace {
+        std::string readPgmToken(std::istream& stream) {
+            std::string token;
+            char character = 0;
+
+            while (stream.get(character)) {
+                if (character == '#') {
+                    stream.ignore(
+                        std::numeric_limits<std::streamsize>::max(),
+                        '\n');
+                    continue;
+                }
+                if (!std::isspace(
+                        static_cast<unsigned char>(character))) {
+                    token.push_back(character);
+                    break;
+                }
+            }
+
+            while (stream.get(character)) {
+                if (character == '#') {
+                    stream.ignore(
+                        std::numeric_limits<std::streamsize>::max(),
+                        '\n');
+                    break;
+                }
+                if (std::isspace(
+                        static_cast<unsigned char>(character))) {
+                    break;
+                }
+                token.push_back(character);
+            }
+            return token;
+        }
+    } // namespace
+
+    HeightMap::HeightMap(
+        std::size_t width,
+        std::size_t depth,
+        float cellSize,
+        std::vector<float> heights,
+        const Vec3& origin)
+        : m_width(width)
+        , m_depth(depth)
+        , m_cellSize(cellSize)
+        , m_origin(origin)
+        , m_heights(std::move(heights)) {
+        validate();
+    }
+
+    HeightMap HeightMap::loadPgm(
+        const std::filesystem::path& path,
+        float cellSize,
+        float heightScale,
+        float heightOffset,
+        const Vec3& origin) {
+
+        std::ifstream stream(path, std::ios::binary);
+        if (!stream) {
+            throw std::runtime_error(
+                "Unable to open PGM heightmap: " + path.string());
+        }
+
+        const std::string magic = readPgmToken(stream);
+        if (magic != "P2" && magic != "P5") {
+            throw std::runtime_error(
+                "Heightmap must be a P2 or P5 PGM file: "
+                + path.string());
+        }
+
+        const std::size_t width = static_cast<std::size_t>(
+            std::stoul(readPgmToken(stream)));
+        const std::size_t depth = static_cast<std::size_t>(
+            std::stoul(readPgmToken(stream)));
+        const int maximumValue = std::stoi(readPgmToken(stream));
+        if (width < 2U || depth < 2U || maximumValue <= 0) {
+            throw std::runtime_error(
+                "Invalid PGM heightmap dimensions or range");
+        }
+        if (magic == "P5" && maximumValue > 255) {
+            throw std::runtime_error(
+                "16-bit binary PGM heightmaps are not yet supported");
+        }
+
+        std::vector<float> heights(width * depth);
+        for (std::size_t index = 0; index < heights.size(); ++index) {
+            int sample = 0;
+            if (magic == "P2") {
+                const std::string token = readPgmToken(stream);
+                if (token.empty()) {
+                    throw std::runtime_error(
+                        "PGM heightmap ended before all samples were read");
+                }
+                sample = std::stoi(token);
+            } else {
+                const int value = stream.get();
+                if (value == std::char_traits<char>::eof()) {
+                    throw std::runtime_error(
+                        "PGM heightmap ended before all samples were read");
+                }
+                sample = value;
+            }
+
+            const float normalizedValue = std::clamp(
+                static_cast<float>(sample)
+                    / static_cast<float>(maximumValue),
+                0.0f,
+                1.0f);
+            heights[index] = heightOffset
+                + normalizedValue * heightScale;
+        }
+        return HeightMap(
+            width,
+            depth,
+            cellSize,
+            std::move(heights),
+            origin);
+    }
+
+    HeightMap HeightMap::generateGradual(
+        std::size_t width,
+        std::size_t depth,
+        float cellSize,
+        float maximumNeighbourStep,
+        std::uint32_t seed,
+        int smoothingPasses,
+        const Vec3& origin) {
+
+        if (width < 2U || depth < 2U) {
+            throw std::invalid_argument(
+                "A heightmap requires at least two vertices per axis");
+        }
+        const float step = std::max(maximumNeighbourStep, 0.001f);
+        std::mt19937 generator(seed);
+        std::uniform_real_distribution<float> offset(-step, step);
+        std::vector<float> heights(width * depth, 0.0f);
+
+        for (std::size_t z = 0; z < depth; ++z) {
+            for (std::size_t x = 0; x < width; ++x) {
+                float lower = -std::numeric_limits<float>::max();
+                float upper = std::numeric_limits<float>::max();
+                float average = 0.0f;
+                int neighbourCount = 0;
+
+                if (x > 0U) {
+                    const float left = heights[z * width + x - 1U];
+                    lower = std::max(lower, left - step);
+                    upper = std::min(upper, left + step);
+                    average += left;
+                    ++neighbourCount;
+                }
+                if (z > 0U) {
+                    const float below = heights[(z - 1U) * width + x];
+                    lower = std::max(lower, below - step);
+                    upper = std::min(upper, below + step);
+                    average += below;
+                    ++neighbourCount;
+                }
+
+                float value = neighbourCount > 0
+                    ? average / static_cast<float>(neighbourCount)
+                        + offset(generator)
+                    : offset(generator);
+                if (lower <= upper) {
+                    value = std::clamp(value, lower, upper);
+                }
+                heights[z * width + x] = value;
+            }
+        }
+
+        std::vector<float> smoothed(heights.size());
+        const int passes = std::clamp(smoothingPasses, 0, 32);
+        for (int pass = 0; pass < passes; ++pass) {
+            for (std::size_t z = 0; z < depth; ++z) {
+                for (std::size_t x = 0; x < width; ++x) {
+                    float sum = 0.0f;
+                    int count = 0;
+                    for (int dz = -1; dz <= 1; ++dz) {
+                        const int sampleZ = static_cast<int>(z) + dz;
+                        if (sampleZ < 0
+                            || sampleZ >= static_cast<int>(depth)) {
+                            continue;
+                        }
+                        for (int dx = -1; dx <= 1; ++dx) {
+                            const int sampleX = static_cast<int>(x) + dx;
+                            if (sampleX < 0
+                                || sampleX >= static_cast<int>(width)) {
+                                continue;
+                            }
+                            sum += heights[
+                                static_cast<std::size_t>(sampleZ) * width
+                                + static_cast<std::size_t>(sampleX)];
+                            ++count;
+                        }
+                    }
+                    smoothed[z * width + x] = sum
+                        / static_cast<float>(count);
+                }
+            }
+            heights.swap(smoothed);
+        }
+
+        float averageHeight = 0.0f;
+        for (float height : heights) {
+            averageHeight += height;
+        }
+        averageHeight /= static_cast<float>(heights.size());
+        for (float& height : heights) {
+            height -= averageHeight;
+        }
+
+        // Normalized box smoothing is normally non-expansive, but scale the
+        // final field defensively so the public neighbour limit is strict at
+        // image boundaries as well as in the interior.
+        float largestNeighbourStep = 0.0f;
+        for (std::size_t z = 0; z < depth; ++z) {
+            for (std::size_t x = 0; x < width; ++x) {
+                const float value = heights[z * width + x];
+                if (x + 1U < width) {
+                    largestNeighbourStep = std::max(
+                        largestNeighbourStep,
+                        std::abs(value - heights[z * width + x + 1U]));
+                }
+                if (z + 1U < depth) {
+                    largestNeighbourStep = std::max(
+                        largestNeighbourStep,
+                        std::abs(value - heights[(z + 1U) * width + x]));
+                }
+            }
+        }
+        if (largestNeighbourStep > step) {
+            const float scale = step / largestNeighbourStep;
+            for (float& height : heights) {
+                height *= scale;
+            }
+        }
+
+        return HeightMap(
+            width,
+            depth,
+            cellSize,
+            std::move(heights),
+            origin);
+    }
+
+    float HeightMap::getHeight(std::size_t x, std::size_t z) const {
+        if (x >= m_width || z >= m_depth) {
+            throw std::out_of_range("Heightmap vertex is out of range");
+        }
+        return m_heights[index(x, z)];
+    }
+
+    void HeightMap::setHeight(
+        std::size_t x,
+        std::size_t z,
+        float height) {
+        if (x >= m_width || z >= m_depth) {
+            throw std::out_of_range("Heightmap vertex is out of range");
+        }
+        m_heights[index(x, z)] = height;
+    }
+
+    float HeightMap::getWorldWidth() const {
+        return m_width > 0U
+            ? static_cast<float>(m_width - 1U) * m_cellSize
+            : 0.0f;
+    }
+
+    float HeightMap::getWorldDepth() const {
+        return m_depth > 0U
+            ? static_cast<float>(m_depth - 1U) * m_cellSize
+            : 0.0f;
+    }
+
+    bool HeightMap::contains(float worldX, float worldZ) const {
+        return worldX >= m_origin.x
+            && worldZ >= m_origin.z
+            && worldX <= m_origin.x + getWorldWidth()
+            && worldZ <= m_origin.z + getWorldDepth();
+    }
+
+    std::optional<float> HeightMap::sampleHeight(
+        float worldX,
+        float worldZ) const {
+
+        if (!contains(worldX, worldZ) || empty()) {
+            return std::nullopt;
+        }
+
+        const float gridX = (worldX - m_origin.x) / m_cellSize;
+        const float gridZ = (worldZ - m_origin.z) / m_cellSize;
+        const std::size_t cellX = std::min(
+            static_cast<std::size_t>(std::floor(gridX)),
+            m_width - 2U);
+        const std::size_t cellZ = std::min(
+            static_cast<std::size_t>(std::floor(gridZ)),
+            m_depth - 2U);
+        const float x = std::clamp(
+            gridX - static_cast<float>(cellX),
+            0.0f,
+            1.0f);
+        const float z = std::clamp(
+            gridZ - static_cast<float>(cellZ),
+            0.0f,
+            1.0f);
+
+        const float h00 = getHeight(cellX, cellZ);
+        const float h10 = getHeight(cellX + 1U, cellZ);
+        const float h01 = getHeight(cellX, cellZ + 1U);
+        const float h11 = getHeight(cellX + 1U, cellZ + 1U);
+
+        float height = 0.0f;
+        if ((cellX + cellZ) % 2U == 0U) {
+            if (x >= z) {
+                height = h00 * (1.0f - x)
+                    + h10 * (x - z)
+                    + h11 * z;
+            } else {
+                height = h00 * (1.0f - z)
+                    + h11 * x
+                    + h01 * (z - x);
+            }
+        } else if (x + z <= 1.0f) {
+            height = h00 * (1.0f - x - z)
+                + h10 * x
+                + h01 * z;
+        } else {
+            height = h10 * (1.0f - z)
+                + h11 * (x + z - 1.0f)
+                + h01 * (1.0f - x);
+        }
+        return m_origin.y + height;
+    }
+
+    std::optional<Vec3> HeightMap::sampleNormal(
+        float worldX,
+        float worldZ) const {
+
+        const auto center = sampleHeight(worldX, worldZ);
+        if (!center) {
+            return std::nullopt;
+        }
+
+        const float offset = std::max(m_cellSize * 0.25f, 0.001f);
+        const float left = sampleHeight(worldX - offset, worldZ)
+            .value_or(*center);
+        const float right = sampleHeight(worldX + offset, worldZ)
+            .value_or(*center);
+        const float below = sampleHeight(worldX, worldZ - offset)
+            .value_or(*center);
+        const float above = sampleHeight(worldX, worldZ + offset)
+            .value_or(*center);
+        return normalized(Vec3{
+            left - right,
+            offset * 2.0f,
+            below - above
+        });
+    }
+
+    std::size_t HeightMap::index(
+        std::size_t x,
+        std::size_t z) const {
+        return z * m_width + x;
+    }
+
+    void HeightMap::validate() const {
+        if (m_width < 2U || m_depth < 2U) {
+            throw std::invalid_argument(
+                "A heightmap requires at least two vertices per axis");
+        }
+        if (m_cellSize <= 0.0f) {
+            throw std::invalid_argument(
+                "Heightmap cell size must be positive");
+        }
+        if (m_heights.size() != m_width * m_depth) {
+            throw std::invalid_argument(
+                "Heightmap sample count does not match its dimensions");
+        }
+    }
+
+} // namespace WidgeCraft

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -1,0 +1,87 @@
+#include "WidgeCraft/terrain/Terrain.hpp"
+
+#include <cmath>
+#include <stdexcept>
+
+namespace WidgeCraft {
+
+    Terrain::Terrain(std::shared_ptr<HeightMap> heightMap)
+        : m_heightMap(std::move(heightMap)) {
+        if (!m_heightMap || m_heightMap->empty()) {
+            throw std::invalid_argument(
+                "Terrain requires a populated heightmap");
+        }
+        rebuildMesh();
+    }
+
+    void Terrain::rebuildMesh() {
+        m_mesh.vertices.clear();
+        m_mesh.indices.clear();
+
+        const std::size_t width = m_heightMap->getWidth();
+        const std::size_t depth = m_heightMap->getDepth();
+        const float cellSize = m_heightMap->getCellSize();
+        const Vec3 origin = m_heightMap->getOrigin();
+
+        m_mesh.vertices.reserve(width * depth);
+        for (std::size_t z = 0; z < depth; ++z) {
+            for (std::size_t x = 0; x < width; ++x) {
+                m_mesh.vertices.push_back({
+                    origin.x + static_cast<float>(x) * cellSize,
+                    origin.y + m_heightMap->getHeight(x, z),
+                    origin.z + static_cast<float>(z) * cellSize
+                });
+            }
+        }
+
+        m_mesh.indices.reserve((width - 1U) * (depth - 1U) * 6U);
+        for (std::size_t z = 0; z + 1U < depth; ++z) {
+            for (std::size_t x = 0; x + 1U < width; ++x) {
+                const std::uint32_t a = static_cast<std::uint32_t>(
+                    z * width + x);
+                const std::uint32_t b = a + 1U;
+                const std::uint32_t d = static_cast<std::uint32_t>(
+                    (z + 1U) * width + x);
+                const std::uint32_t c = d + 1U;
+
+                if ((x + z) % 2U == 0U) {
+                    m_mesh.indices.insert(
+                        m_mesh.indices.end(),
+                        { a, c, b, a, d, c });
+                } else {
+                    m_mesh.indices.insert(
+                        m_mesh.indices.end(),
+                        { a, d, b, b, d, c });
+                }
+            }
+        }
+    }
+
+    void Terrain::draw(
+        Shapes3D& shapes,
+        const ShapeStyle3D& style,
+        const Vec3& viewPosition,
+        float drawDistance) const {
+
+        if (drawDistance <= 0.0f) {
+            shapes.drawMesh(m_mesh, {}, style);
+            return;
+        }
+
+        const float distanceSquared = drawDistance * drawDistance;
+        for (std::size_t index = 0;
+             index + 2U < m_mesh.indices.size();
+             index += 3U) {
+            const Vec3& a = m_mesh.vertices[m_mesh.indices[index]];
+            const Vec3& b = m_mesh.vertices[m_mesh.indices[index + 1U]];
+            const Vec3& c = m_mesh.vertices[m_mesh.indices[index + 2U]];
+            const Vec3 center = (a + b + c) / 3.0f;
+            const float dx = center.x - viewPosition.x;
+            const float dz = center.z - viewPosition.z;
+            if (dx * dx + dz * dz <= distanceSquared) {
+                shapes.drawTriangle(a, b, c, style);
+            }
+        }
+    }
+
+} // namespace WidgeCraft

--- a/src/ui/Widget.cpp
+++ b/src/ui/Widget.cpp
@@ -4,6 +4,7 @@
 #include "WidgeCraft/ShapeRenderer.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 namespace WidgeCraft {
@@ -301,6 +302,130 @@ namespace WidgeCraft {
             }
             textRenderer.renderText(m_text, textX, textY, textSize, textColor);
         }
+    }
+
+    Slider::Slider(
+        std::string name,
+        float minimum,
+        float maximum,
+        float value)
+        : Widget(std::move(name)) {
+        setRange(minimum, maximum);
+        setValue(value);
+    }
+
+    void Slider::setRange(float minimum, float maximum) {
+        m_minimum = std::min(minimum, maximum);
+        m_maximum = std::max(minimum, maximum);
+        if (m_maximum - m_minimum < 0.0001f) {
+            m_maximum = m_minimum + 0.0001f;
+        }
+        m_value = quantize(m_value);
+    }
+
+    void Slider::setValue(float value) {
+        m_value = quantize(value);
+    }
+
+    float Slider::quantize(float value) const {
+        float result = std::clamp(value, m_minimum, m_maximum);
+        if (m_step > 0.0f) {
+            const float safeStep = std::max(m_step, 0.000001f);
+            result = m_minimum
+                + std::round((result - m_minimum) / safeStep) * safeStep;
+            result = std::clamp(result, m_minimum, m_maximum);
+        }
+        return result;
+    }
+
+    void Slider::setValueFromPointer(
+        float pointerX,
+        const Rect& track) {
+
+        const float ratio = track.width > 0.0f
+            ? std::clamp((pointerX - track.x) / track.width, 0.0f, 1.0f)
+            : 0.0f;
+        const float next = quantize(
+            m_minimum + ratio * (m_maximum - m_minimum));
+        if (std::abs(next - m_value) <= 0.0001f) {
+            return;
+        }
+        m_value = next;
+        if (m_onChanged) {
+            m_onChanged(m_value);
+        }
+    }
+
+    void Slider::render(
+        Frame& frame,
+        TextRenderer& textRenderer,
+        ShapeRenderer& shapeRenderer,
+        const Input& input) {
+
+        (void)textRenderer;
+        const Rect rect = resolveRect(frame, { 240.0f, 30.0f });
+        setComputedSize(rect.width, rect.height);
+
+        const float thumbRadius = std::min(10.0f, rect.height * 0.36f);
+        const Rect track{
+            rect.x + thumbRadius,
+            rect.y + rect.height * 0.5f - 3.0f,
+            std::max(0.0f, rect.width - thumbRadius * 2.0f),
+            6.0f
+        };
+        const bool hovered = isEnabled() && rect.contains(input.mousePosition());
+        if (!isEnabled()) {
+            m_dragging = false;
+        } else {
+            if (input.mousePressed(MouseButton::Left) && hovered) {
+                m_dragging = true;
+                setValueFromPointer(input.mousePosition().x, track);
+            }
+            if (m_dragging && input.mouseDown(MouseButton::Left)) {
+                setValueFromPointer(input.mousePosition().x, track);
+            }
+            if (input.mouseReleased(MouseButton::Left)) {
+                m_dragging = false;
+            }
+        }
+
+        const float ratio = (m_value - m_minimum)
+            / (m_maximum - m_minimum);
+        const float thumbX = track.x + ratio * track.width;
+        Color trackColor = m_trackColor;
+        Color fillColor = m_fillColor;
+        Color thumbColor = m_thumbColor;
+        if (!isEnabled()) {
+            trackColor.a *= 0.45f;
+            fillColor.a *= 0.45f;
+            thumbColor.a *= 0.45f;
+        }
+
+        shapeRenderer.drawFilledRect(
+            track.x,
+            track.y,
+            track.width,
+            track.height,
+            trackColor);
+        shapeRenderer.drawFilledRect(
+            track.x,
+            track.y,
+            std::max(0.0f, thumbX - track.x),
+            track.height,
+            fillColor);
+        shapeRenderer.drawFilledCircle(
+            thumbX,
+            rect.y + rect.height * 0.5f,
+            thumbRadius,
+            hovered || m_dragging
+                ? Color{
+                    std::min(thumbColor.r + 0.12f, 1.0f),
+                    std::min(thumbColor.g + 0.08f, 1.0f),
+                    thumbColor.b,
+                    thumbColor.a
+                }
+                : thumbColor,
+            24);
     }
 
 } // namespace WidgeCraft


### PR DESCRIPTION
## What changed

- Added CPU object draw-distance culling paired with the model viewport camera far plane.
- Added reusable 3D and projected 2D meshes with batched mesh drawing.
- Added Wavefront OBJ plus ASCII/binary STL model loading and example assets.
- Added an object manager with rendered, interactable, collidable, fixed, gravity, trigger, selectable, enabled, and label attributes.
- Added managed physics-body synchronization, interaction raycasts, trigger queries, and non-resolving trigger collision events.
- Added P2/P5 PGM heightmaps, strict neighbour-limited seeded terrain generation, alternating-diagonal terrain meshes, and matching heightfield physics sampling.
- Added a retained UI slider.
- Added a terrain movement sandbox with gravity and jumping.
- Added a 1,000-object OBJ/STL batching sandbox with SDF ID labels, draw-distance control, CPU queue timing, and memory statistics.
- Updated the engine to version 0.7.0 and documented the new APIs and Visual Studio projects.

## Why

These systems provide the next reusable engine layer for larger scenes: terrain, imported geometry, object attributes, triggers, and CPU-side distance culling. The sandboxes make slope movement and high-count batching measurable instead of leaving the APIs unintegrated.

## Design notes

Heightmaps use a square grid split into alternating right-triangle diagonals. This maps directly to image rows and columns, avoids a consistent diagonal bias, and lets rendering and collision sample the same surface exactly.

The first model-loader layer imports triangle geometry. Materials, textures, imported normals, rotational dynamics, and general mesh colliders remain future work.

## Validation

- Configured and built all Win32 Release targets successfully.
- Passed assertions for neighbour-limited height generation, terrain sampling, gravity settling, jumping, trigger overlap, OBJ loading, STL loading, and 2D mesh projection.
- Passed five-second runtime smoke tests for the terrain and 1,000-object batching sandboxes.
- Passed the existing interactive-world `--world` regression smoke test.
- Passed `git diff --check` (Windows line-ending conversion notices only).